### PR TITLE
Pkg 3551 - internal cuda/linux-64 build - b2408 - skip CI

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,6 @@ MACOSX_DEPLOYMENT_TARGET:   # [osx and x86_64]
 blas_impl:
   - mkl        # [linux or win]
   - accelerate # [osx]
+
+cuda_compiler_version: # [linux and x86_64]
+  - 11.8               # [linux and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,3 +10,6 @@ cuda_compiler_version: # [linux and x86_64]
 
 cuda_compiler:         # [linux and x86_64]
   - cuda-nvcc          # [linux and x86_64]
+
+cpu_variant:
+  - main_channel_default

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,4 +9,4 @@ cuda_compiler_version: # [linux and x86_64]
   - 12.3               # [linux and x86_64]
 
 cuda_compiler:         # [linux and x86_64]
-  - nvcc               # [linux and x86_64]
+  - cuda-nvcc          # [linux and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,4 +6,7 @@ blas_impl:
   - accelerate # [osx]
 
 cuda_compiler_version: # [linux and x86_64]
-  - 11.8               # [linux and x86_64]
+  - 12.3               # [linux and x86_64]
+
+cuda_compiler:         # [linux and x86_64]
+  - nvcc               # [linux and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,10 @@ build:
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [(osx and x86_64) or cuda_compiler_version == "None"]
   string: mps_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [osx and arm64]
+  missing_dso_whitelist:
+    - "**/libcuda.so*"
+
+
  
   script:
     - LLAMA_ARGS="-DLLAMA_BUILD_TESTS=OFF"              # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp" %}
-{% set version = "0.0.1661" %}
+{% set version = "0.0.2144" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,18 @@ package:
 
 source:
   url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
-  sha256: 88b4befe7d44b18e9419a0604adad2c130bfea9af45100b8531822bb2e1184fb
+  sha256: 679d2deb41b9df3d04bc5fb3b8fd255717009a08927962eca6476f26bff74731
   patches:
     - osx-64-pick-discrete.patch  # [osx]
     - mkl.patch                   # [blas_impl == "mkl"]
 
 build:
   number: 0
+  skip: true # [not (linux and x86_64) or (cuda_compiler_version == "None")]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [(osx and x86_64) or cuda_compiler_version == "None"]
   string: mps_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [osx and arm64]
-
+ 
   script:
     - LLAMA_ARGS="-DLLAMA_BUILD_TESTS=OFF"              # [unix]
     - set LLAMA_ARGS=-DLLAMA_BUILD_TESTS=OFF            # [win]
@@ -50,6 +51,9 @@ build:
     - echo $LLAMA_ARGS  # [unix]
     - set LLAMA_ARGS    # [win]
 
+    - export CUDACXX=/usr/local/cuda/bin/nvcc   # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - export CUDAHOSTCXX="${CXX}"               # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+
     - cmake -S . -B build -G Ninja %CMAKE_ARGS% %LLAMA_ARGS%    # [win]
     - cmake -S . -B build -G Ninja ${CMAKE_ARGS} ${LLAMA_ARGS}  # [unix]
     - cmake --build build
@@ -59,23 +63,24 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler('cuda') }}                        # [cuda_compiler_version != "None"]
+    - {{ compiler('cuda') }}                        # [(cuda_compiler_version or "").startswith("12")]
     - cmake
     - git
     - ninja
     - pkgconfig
   host:
     # NOTE: Without cuda-version, we are installing cuda-toolkit 11.8 instead of 11.2!
-    - cuda-version     {{ cuda_compiler_version }}  # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - cudatoolkit      {{ cuda_compiler_version }}  # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
     - cuda-cudart-dev  {{ cuda_compiler_version }}  # [(cuda_compiler_version or "").startswith("12")]
     - libcublas-dev    {{ cuda_compiler_version }}  # [(cuda_compiler_version or "").startswith("12")]
 
     - blas-devel * *{{ blas_impl }}                 # [not osx and cuda_compiler_version == "None" and blas_impl == "mkl"]
     - mkl-devel {{ mkl }}                           # [not osx and cuda_compiler_version == "None" and blas_impl == "mkl"]
   run:
-    - cuda-version {{ cuda_compiler_version }}      # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
 
     - llvm-openmp                                   # [linux and cuda_compiler_version == "None" and blas_impl == "mkl"]
+    - __cuda >={{ cuda_compiler_version }}          # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ build:
 
     {{ cmake_args("BUILD_SHARED_LIBS=ON") }}
 
-    {{ llama_args("NATIVE=OFF") }}      # [(osx and arm64) or win]
+    {{ llama_args("NATIVE=OFF") }}      # [cpu_variant == "main_channel_default"]
     {{ llama_args("AVX=OFF") }}         # [osx and arm64]
     {{ llama_args("AVX2=OFF") }}        # [osx and arm64]
     {{ llama_args("FMA=OFF") }}         # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,7 @@ build:
 
     - export CUDACXX=/usr/local/cuda/bin/nvcc   # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
     - export CUDAHOSTCXX="${CXX}"               # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - export LDFLAGS="$LDFLAGS -Wl,-rpath-link,/usr/lib64"    # [(cuda_compiler_version or "").startswith("12")]
 
     - cmake -S . -B build -G Ninja %CMAKE_ARGS% %LLAMA_ARGS%    # [win]
     - cmake -S . -B build -G Ninja ${CMAKE_ARGS} ${LLAMA_ARGS}  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,6 @@ build:
   string: mps_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [osx and arm64]
   missing_dso_whitelist:
     - "**/libcuda.so*"
-
-
  
   script:
     - LLAMA_ARGS="-DLLAMA_BUILD_TESTS=OFF"              # [unix]
@@ -74,8 +72,8 @@ requirements:
     - ninja
     - pkgconfig
   host:
-    # NOTE: Without cuda-version, we are installing cuda-toolkit 11.8 instead of 11.2!
     - cudatoolkit      {{ cuda_compiler_version }}  # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - cuda-version     {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - cuda-cudart-dev  {{ cuda_compiler_version }}  # [(cuda_compiler_version or "").startswith("12")]
     - libcublas-dev    {{ cuda_compiler_version }}  # [(cuda_compiler_version or "").startswith("12")]
 
@@ -83,6 +81,7 @@ requirements:
     - mkl-devel {{ mkl }}                           # [not osx and cuda_compiler_version == "None" and blas_impl == "mkl"]
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}  # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]
+    - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [cuda_compiler_version != "None"]
 
     - llvm-openmp                                   # [linux and cuda_compiler_version == "None" and blas_impl == "mkl"]
     - __cuda >={{ cuda_compiler_version }}          # [cuda_compiler_version != "None" and not (cuda_compiler_version or "").startswith("12")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp" %}
-{% set version = "0.0.2144" %}
+{% set version = "0.0.2408" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
-  sha256: 679d2deb41b9df3d04bc5fb3b8fd255717009a08927962eca6476f26bff74731
+  sha256: 163255cb77599be6f97c487bcdce79912c7509a9c522ad4ab5b23cc4104d0bb4
   patches:
     - osx-64-pick-discrete.patch  # [osx]
     - mkl.patch                   # [blas_impl == "mkl"]

--- a/recipe/mkl.patch
+++ b/recipe/mkl.patch
@@ -1,13 +1,13 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0639518..4417d5a 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -240,7 +240,7 @@ if (LLAMA_BLAS)
-         message(STATUS "BLAS found, Includes: ${BLAS_INCLUDE_DIRS}")
-         add_compile_options(${BLAS_LINKER_FLAGS})
+Index: llama.cpp/CMakeLists.txt
+===================================================================
+--- llama.cpp.orig/CMakeLists.txt	2024-03-12 17:04:04.689586131 -0500
++++ llama.cpp/CMakeLists.txt	2024-03-12 17:04:23.088997153 -0500
+@@ -331,7 +331,7 @@
+ 
          add_compile_definitions(GGML_USE_OPENBLAS)
+ 
 -        if (${BLAS_INCLUDE_DIRS} MATCHES "mkl" AND (${LLAMA_BLAS_VENDOR} MATCHES "Generic" OR ${LLAMA_BLAS_VENDOR} MATCHES "Intel"))
 +        if ((${BLAS_INCLUDE_DIRS} MATCHES "mkl" AND ${LLAMA_BLAS_VENDOR} MATCHES "Generic") OR ${LLAMA_BLAS_VENDOR} MATCHES "Intel")
              add_compile_definitions(GGML_BLAS_USE_MKL)
          endif()
-         set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} ${BLAS_LIBRARIES})
+ 


### PR DESCRIPTION
**Destination channel:** internal anaconda.org channel

### Links

- [PKG-3551](https://anaconda.atlassian.net/browse/PKG-3551) 
- [Upstream repository](https://github.com/ggerganov/llama.cpp/tree/b2408)
- [Upstream changelog/diff](https://github.com/ggerganov/llama.cpp/releases/tag/b2408)

### Explanation of changes:

- This is for internal delivery to the anaconda enterprise team for use in AI assistant
- It is built for CUDA 12.3 and our default CPU architecture (Nocona)
- There are still some product-related questions to be answered around how we handle this if we were to release to defaults, around CPU-optimized variants and update cadence, but this should help the Assistant team for now and satisfy the immediate deliverable I think?
- [log](https://github.com/AnacondaRecipes/llama.cpp-feedstock/files/14643371/3aftertidyforPR.log)


[PKG-3551]: https://anaconda.atlassian.net/browse/PKG-3551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ