### PR TITLE
update to b2956

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -38,6 +38,7 @@ cmake -S . -B build ^
     -DLLAMA_AVX512=OFF ^
     -DLLAMA_AVX512_VBMI=OFF ^
     -DLLAMA_AVX512_VNNI=OFF ^
+    -DLLAMA_AVX512_BF16=OFF ^
     -DLLAMA_FMA=OFF
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,9 @@ if [[ ${gpu_variant:0:5} = "cuda-" ]]; then
     if [[ ${gpu_variant:-} = "cuda-11" ]]; then
         export CUDACXX=/usr/local/cuda/bin/nvcc
         export CUDAHOSTCXX="${CXX}"
+    else
+        # cuda-compat provided libcuda.so.1
+        LDFLAGS="$LDFLAGS -Wl,-rpath-link,${PREFIX}/cuda-compat/"
     fi
 elif [[ ${gpu_variant:-} = "none" ]]; then
     LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_CUDA=OFF"
@@ -67,25 +70,14 @@ if [[ ${gpu_variant:0:5} = "cuda-" ]]; then
     # f16 CUDA intrinsics (available from 60 - Pascal), and us compiling with CUDA architectures all.
     # See https://github.com/ggerganov/llama.cpp/blob/b2781/CMakeLists.txt#L439-L451
     # LLAMA_CUDA_F16 is optional, but the corresponding tests are not skipped by default.
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,1],nr=[1,1]): [MUL_MAT] NMSE = 0.995356906 > 0.0005000
-    # 00 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,1],nr=[2,1]): [MUL_MAT] NMSE = 0.999567945 > 0.0005000
-    # 00 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[1,1]): [MUL_MAT] inf mismatch: CUDA0=-inf CPU=
-    # 3.371366 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[2,1]): [MUL_MAT] inf mismatch: CUDA0=-inf CPU=
-    # 6.707091 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[1,2]): not supported [CUDA0]
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[2,2]): not supported [CUDA0]
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[1,1],nr=[1,1]): OK
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,1],nr=[1,1]): [MUL_MAT] NMSE = 1.002334163 > 0.000500
-    # 000 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,1],nr=[2,1]): [MUL_MAT] NMSE = 1.000352589 > 0.000500
-    # 000 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,10],nr=[1,1]): [MUL_MAT] NMSE = 1.000091733 > 0.00050
-    # 0000 FAIL
-    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,10],nr=[2,1]): [MUL_MAT] NMSE = 1.000184368 > 0.00050
-    # 0000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,1],nr=[1,1]): [MUL_MAT] NMSE = 0.993871958 > 0.000500000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,1],nr=[2,1]): [MUL_MAT] NMSE = 1.002262239 > 0.000500000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[1,1]): [MUL_MAT] inf mismatch: CUDA0=-inf CPU=9.985199 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=1,k=256,bs=[10,10],nr=[2,1]): [MUL_MAT] inf mismatch: CUDA0=-inf CPU=-4.107816 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,1],nr=[1,1]): [MUL_MAT] NMSE = 1.002217055 > 0.000500000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,1],nr=[2,1]): [MUL_MAT] NMSE = 1.001445591 > 0.000500000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,10],nr=[1,1]): [MUL_MAT] NMSE = 1.000128216 > 0.000500000 FAIL
+    #   MUL_MAT(type_a=f16,type_b=f16,m=16,n=16,k=256,bs=[10,10],nr=[2,1]): [MUL_MAT] NMSE = 1.000069965 > 0.000500000 FAIL
     ctest --output-on-failure build -j${CPU_COUNT} || true
 else
     ctest --output-on-failure build -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,11 +7,6 @@ if [[ ${gpu_variant:0:5} = "cuda-" ]]; then
     if [[ ${gpu_variant:-} = "cuda-11" ]]; then
         export CUDACXX=/usr/local/cuda/bin/nvcc
         export CUDAHOSTCXX="${CXX}"
-    else
-        LDFLAGS="$LDFLAGS -Wl,-rpath-link,${PREFIX}/lib/stubs/"
-        # TODO: This is a workaround. In the future, consider using cuda-compat instead of 
-        # cuda-driver-dev to provide libcuda.so.1
-        ln -s ${PREFIX}/lib/stubs/libcuda.so ${PREFIX}/lib/stubs/libcuda.so.1
     fi
 elif [[ ${gpu_variant:-} = "none" ]]; then
     LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_CUDA=OFF"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,7 +26,7 @@ gpu_variant:
 cuda_compiler_version:         # [win or (linux and x86_64)]
   - none                       # [win or (linux and x86_64)]
   - 11.8                       # [(linux and x86_64)]
-  - 12.3                       # [win or (linux and x86_64)]
+  - 12.4                       # [win or (linux and x86_64)]
 
 cuda_compiler:                 # [win or (linux and x86_64)]
 - cuda-nvcc                    # [win or (linux and x86_64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp" %}
-{% set version = "0.0.2901" %}
+{% set version = "0.0.2956" %}
 {% set build_number = 0 %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
-  sha256: 38ab7ff358e7225a3de181ab9e634865635d93cdba5172904c218e6dc41d5b0d
+  sha256: a91b894ecb9c8a46b07f2b648098770cfab9820a2ae8739a96ea8d68ee7a45ec
   patches:
     - patches/test_exe_threads.patch      # [linux]
     - patches/mkl.patch                   # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp" %}
-{% set version = "0.0.2781" %}
+{% set version = "0.0.2901" %}
 {% set build_number = 0 %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
-  sha256: e6b64870e4798301b4f98849dfd83bb6bad9e8d3eb08a8395707c9495fe8ff54
+  sha256: 38ab7ff358e7225a3de181ab9e634865635d93cdba5172904c218e6dc41d5b0d
   patches:
     - patches/test_exe_threads.patch      # [linux]
     - patches/mkl.patch                   # [blas_impl == "mkl"]
@@ -49,7 +49,7 @@ requirements:
     - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
     - cuda-cudart-dev  {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda') and (gpu_variant != "cuda-11")]
     - libcublas-dev    {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda') and (gpu_variant != "cuda-11")]
-    - cuda-driver-dev  {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda') and (gpu_variant != "cuda-11") and linux]
+    - cuda-compat      {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda') and (gpu_variant != "cuda-11") and linux]
     - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
     - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
   run:


### PR DESCRIPTION
llama.cpp b2956

**Destination channel:** ai-staging

### Links

- https://anaconda.atlassian.net/browse/PKG-4818
- https://github.com/ggerganov/llama.cpp/tree/b2956
- https://github.com/ggerganov/llama.cpp/releases

### Explanation of changes:

- update to b2956
- cuda compiler 12.4
- use cuda-compat instead of cuda-driver-dev
