### PR TITLE
Include package variant with optimization for x86-64-v3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,6 +23,14 @@ if "%blas_impl%"=="mkl" (
     set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BLAS=OFF
 )
 
+if "%x86_64_opt%"=="v3" (
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_AVX=ON
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_AVX2=ON
+) else (
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_AVX=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_AVX2=OFF
+)
+
 cmake -S . -B build ^
     -G Ninja ^
     !CMAKE_ARGS! ^
@@ -33,8 +41,6 @@ cmake -S . -B build ^
     -DLLAMA_BUILD_TESTS=ON  ^
     -DBUILD_SHARED_LIBS=ON  ^
     -DLLAMA_NATIVE=OFF ^
-    -DLLAMA_AVX=OFF ^
-    -DLLAMA_AVX2=OFF ^
     -DLLAMA_AVX512=OFF ^
     -DLLAMA_AVX512_VBMI=OFF ^
     -DLLAMA_AVX512_VNNI=OFF ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,6 +45,12 @@ else
     LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_BLAS=OFF"
 fi
 
+if [[ ${x86_64_opt:-} = "v3" ]]; then
+    export CXXFLAGS="${CXXFLAGS/march=nocona/march=x86-64-v3}"
+    export CFLAGS="${CFLAGS/march=nocona/march=x86-64-v3}"
+    export CPPFLAGS="${CPPFLAGS/march=nocona/march=x86-64-v3}"
+fi
+
 cmake -S . -B build \
     -G Ninja \
     ${CMAKE_ARGS} \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+x86_64_opt:
+  - none
+  - v3                         # [(x86 or x86_64) and not osx]
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas                   # [not win and not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,18 @@ build:
   skip: true # [gpu_variant == "cuda-11"]
   # do not mix cublas and mkl/openblas
   skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
+  # do not mix CPU optimization with cublas
+  skip: true # [x86_64_opt == "v3" and gpu_variant != "none"]
   # Use a build number difference to ensure that the GPU
   # variant is slightly preferred by conda's solver, so that it's preferentially
   # installed where the platform supports it.
   number: {{ build_number + 200 }}  # [(gpu_variant or "").startswith('cuda') and (gpu_variant != "cuda-11")]
   number: {{ build_number + 100 }}  # [(gpu_variant == "cuda-11") or (gpu_variant == "metal")]
-  number: {{ build_number }}        # [gpu_variant == "none"]
+  number: {{ build_number + 50 }}   # [gpu_variant == "none" and x86_64_opt == "v3"]
+  number: {{ build_number }}        # [gpu_variant == "none" and x86_64_opt == "none"]
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith('cuda')]
-  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [gpu_variant == "none"]
+  string: cpu_v3_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                              # [gpu_variant == "none" and x86_64_opt == "v3"]
+  string: cpu_{{ blas_impl }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                 # [gpu_variant == "none" and x86_64_opt == "none"]
   string: mps_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                 # [gpu_variant == "metal"]
   missing_dso_whitelist:                                                                         # [s390x or (gpu_variant or "").startswith('cuda')]
     - "**/libcuda.so*"                                                                           # [(gpu_variant or "").startswith('cuda')]
@@ -62,6 +66,7 @@ requirements:
     - llvm-openmp                                         # [osx] bounds through run_exports
     - _openmp_mutex                                       # [linux]
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}  # [osx and x86_64]
+    - _x86_64-microarch-level >=3                         # [x86_64_opt == "v3"]
 
 test:
   commands:


### PR DESCRIPTION
Include a variant on linux-64 and win-64 that has optimizations for the x86-64-v3 feature level. This variant includes optimization that use the AVX and AVX2 instructions set. This variant is restricted from being installed on incompatible system via a dependency on the `_x86_64-microarch-level >=3` package. 
