### PR TITLE
Update llama.cpp, llama.cpp-tools and gguf to b4575

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "4418" %}
+{% set upstream_release = "4575" %}
 {% set version = "0.0." + upstream_release %}
 # the `gguf_version` should match gguf-py/pyproject.toml's version number but append the upstream release 
 # number, remember to check the upstream pyproject.toml file for new version numbers when doing a feedstock 
@@ -7,7 +7,7 @@
 #
 # This is due to upstream making changes to the gguf-py package without incrementing the version number, we add
 # the upstream release number to the version number to ensure that the version number is incremented.
-{% set gguf_version = "0.13." + upstream_release %}
+{% set gguf_version = "0.15." + upstream_release %}
 {% set build_number = 0 %}
 
 # `llama.cpp-meta` is a meta-package that includes the `llama.cpp`, `llama.cpp-tools` and `gguf` packages:
@@ -228,10 +228,10 @@ outputs:
     version: {{ gguf_version }}
     build:
       entry_points:
-        - gguf-convert-endian = scripts:gguf_convert_endian_entrypoint
-        - gguf-dump = scripts:gguf_dump_entrypoint
-        - gguf-set-metadata = scripts:gguf_set_metadata_entrypoint
-        - gguf-new-metadata = scripts:gguf_new_metadata_entrypoint
+        - gguf-convert-endian = gguf.scripts:gguf_convert_endian_entrypoint
+        - gguf-dump = gguf.scripts:gguf_dump_entrypoint
+        - gguf-set-metadata = gguf.scripts:gguf_set_metadata_entrypoint
+        - gguf-new-metadata = gguf.scripts:gguf_new_metadata_entrypoint
       skip: True # [py<39]
       number: {{ build_number }}
 

--- a/recipe/patches/metal_gpu_selection.patch
+++ b/recipe/patches/metal_gpu_selection.patch
@@ -12,21 +12,21 @@ https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discu
 I did try linking to CoreGraphics, but MTLCreateSystemDefaultDevice was still returning nil.
 ---
 diff --git a/ggml/src/ggml-metal/ggml-metal.m b/ggml/src/ggml-metal/ggml-metal.m
-index c247b50c..8028f700 100644
+index 76f8e429..0f9fa5f3 100644
 --- a/ggml/src/ggml-metal/ggml-metal.m
 +++ b/ggml/src/ggml-metal/ggml-metal.m
-@@ -59,6 +59,25 @@
+@@ -64,6 +64,25 @@
  
      if (ctx->mtl_device == nil) {
          ctx->mtl_device = MTLCreateSystemDefaultDevice();
 +        if (ctx->mtl_device == nil) {
-+            /*
++          /*
 +            In macOS, in order for the system to provide a default Metal device object, you must link to the Core Graphics framework.
 +            You usually need to do this explicitly if you're writing apps that don't use graphics by default, such as command line tools.
 +            > https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice?language=objc
 +            Systems with Apple silicon only have one GPU, which removes the need to choose a GPU.
 +            > https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discussion
-+            */
++           */
 +            NSArray * devices = MTLCopyAllDevices();
 +            for (id<MTLDevice> dev in devices) {
 +                if (dev != nil) {
@@ -38,9 +38,8 @@ index c247b50c..8028f700 100644
 +                }
 +            }
 +        }
+     }
  
-         ctx->has_simdgroup_reduction  = [ctx->mtl_device supportsFamily:MTLGPUFamilyApple7];
-         ctx->has_simdgroup_reduction |= [ctx->mtl_device supportsFamily:MTLGPUFamilyMetal3_GGML];
--- 
-2.39.3 (Apple Git-146)
+     if (ctx->mtl_device) {
+
 


### PR DESCRIPTION
llama.cpp 0.0.4575
llama.cpp-tools 0.0.4575
gguf 0.15.4575

**Destination channel:** ai-staging

### Links

- [Upstream repository](https://github.com/ggerganov/llama.cpp)
- [Upstream changelog/diff](https://github.com/ggerganov/llama.cpp/releases)

### Explanation of changes:


Analyzing changes between b4418 and b4575:

## Summary
- Total commits: 157
- Files changed: 256
- Important files modified: 6

## Changes by Category

### Llama-Run
- llama-run: fix context size (#11094)

### Llama
- llama: use _impl suffix instead of _internal (#11060)
- llama: use LLAMA_TOKEN_NULL (#11062)
- llama: update llama_model API names (#11063)
- llama: rename missed batch params/vars to ubatch (#10059)
- llama: prevent system info string accumulation across calls (#11101)
- llama: remove check flash_attn with lora (#11104)
- llama: remove unused headers (#11109)
- llamafile: ppc64le MMA INT8 implementation (#10912)
- llama: avoid hardcoded QK_K (#11061)
- llama-chat: add phi 4 template (#11148)
- llama: add support for QRWKV6 model architecture (#11001)
- llama: add `llama_vocab`, functions -> methods, naming (#11110)
- llama: remove notion of CLS token (#11064)
- llama: fix chat template gguf key (#11201)
- llama: remove 'd' from bad special token log (#11212)
- llama: add `llama_model_load_from_splits` (#11255)
- llama: add internlm3 support (#11233)
- llama: fix deprecation message: vocabable -> vocab (#11269)
- llama.android: add field formatChat to control whether to parse special tokens when send message (#11270)
- llama: re-add LLM_ARCH_PHIMOE (#11305)
- llama: add support for Deepseek-R1-Qwen distill model (#11310)
- llama: refactor llama_decode_impl (#11381)
- llama: minor fixes for up llama load model speed (#11448)

### Common
- common: support tag-based --hf-repo like on ollama (#11195)
- common: add -hfd option for the draft model (#11318)

### Convert
- convert: add --print-supported-models option (#11172)
- convert: sort print supported models [no ci] (#11179)

### Server
- server: fix extra BOS in infill endpoint (#11106)
- server: add tooltips to settings and themes btn (#11154)
- server: (UI) Support for RTL text as models input or output (#11208)
- server: (UI) Improve messages bubble shape in RTL (#11220)
- server: Improve code snippets direction between RTL text (#11221)
- server: implement cancellable request (#11285)
- server: fix draft context not being released (#11354)
- server: add more clean up when cancel_tasks is called (#11340)
- server: (webui) put DeepSeek R1 CoT in a collapsible <details> element (#11364)
- server: fix cleaning up stream task (#11418)

### RPC-Server
- rpc: code cleanup (#11107)
- rpc: early register backend devices (#11262)
- rpc: better caching of the base buffer pointer (#11331)
- rpc: fix register position (#11424)

### GGUF
- ggml-backend: only offload from host buffers (#11120)
- ggml-backend: only offload from host buffers (fix) (#11124)
- GGUF: C++ refactor, backend support, misc fixes (#11030)
- gguf-py: move scripts directory (#11116)
- gguf-py: fixed local detection of gguf package (#11180)

### GGML
- ggml: allow loading backend with env variable (ggml/1059)
- ggml: do not define GGML_USE_CUDA when building with GGML_BACKEND_DL (#11211)
- ggml: aarch64: implement SVE kernels for q4_K_q8_K vector dot (#11227)

### Models
- model: Add support for PhiMoE arch (#11003)

### Bug Fixes
- fix: Vulkan shader gen binary path when Cross-compiling (#11096)
- fix: add missing msg in static_assert (#11143)
- fix: ggml: fix vulkan-shaders-gen build (#10448)

### Vulkan
- Vulkan: Fix float16 use on devices without float16 support + fix subgroup_size_control validation error (#11161)
- vulkan: scale caching for k quants + misc fixes (#11081)
- vulkan: optimize coopmat2 q2_k dequant function (#11130)
- vulkan: optimize coopmat2 q4_k/q5_k dequant functions. (#11206)
- vulkan: support copy from f32 to q4_0/q4_1/q5_0/q5_1/q8_0/iq4_nl (#11166)
- vulkan: fix coopmat2 flash attention for non-contiguous inputs (#11281)
- vulkan: fix coopmat2 validation failures (#11284)
- vulkan: fix diag_mask_inf (#11323)
- vulkan: sort shaders for more deterministic binary (#11315)
- Vulkan-run-test: fix mmq_wg_denoms (#11343)
- vulkan: compile shaders on-demand (#11406)

### SYSCL
- SYCL: Use get_multi_ptr instead of deprecated get_pointer in wkv6 (#11087)
- SYCL: Refactor ggml_sycl_compute_forward (#11121)
- SYCL: Add gated linear attention kernel (#11175)
- SYCL: Introducing memory host pool (#11251)
- SYCL: SOFTMAX F16 mask support and other fixes (#11261)

### CUDA
- CUDA: add BF16 support (#11093)
- cuda: CUDA Graph Compute Function Refactor (precursor for performance improvements) (#11042)
- CUDA: backwards pass for misc. ops, add tests (#11257)
- CUDA: fix FP16 cuBLAS GEMM (#11396)

### Metal
- metal: fix out-of-bounds write (#11314)
- metal: use residency sets (#11427)
- metal: Handle null returned from MTLCreateSystemDefaultDevice() (#11441)

### Scripts
- scripts: sync opencl
- scripts: sync gguf
- scripts: sync gguf (cont)
- scripts: restore hf.sh (#11288)

### Llava
- llava: support Minicpm-omni (#11289)

### Build System
- ci: fix cmake option (#11125)
- ci: pin dependency to specific version (#11137)
- ci: use actions from ggml-org (#11140)
- ci: add -no-cnv for tests (#11238)
- ci: use -no-cnv in gguf-split tests (#11254)
- cmake: add sanitizer flags for llama.cpp (#11279)
- cmake: fix shell command quoting in build-info script (#11309)
- cmake: avoid -march=native when reproducible build is wanted (#11366)
- ci: fix line breaks on windows builds (#11409)
- build: add /bigobj to MSVC build (#11407)
- build: apply MSVC /bigobj option to c/cpp files only (#11423)
- cmake: add ggml find package (#11369)
- cmake: don't fail on `GGML_CPU=OFF` (#11457)

### Tests
- tests: increase timeout when sanitizers are enabled (#11300)
- tests: fix some mul_mat test gaps (#11375)

### Documentation
- doc: add cuda guide for fedora (#11135)
- README: added kalavai to infrastructure list (#11216)
- readme: add plugin links (#11355)
- docs: Update readme to build targets for local docker build (#11368)
- docker: fix CPU ARM build (#11403)
- docker: add GGML_CPU_ARM_ARCH arg to select ARM architecture to build for (#11419)
- readme: update hot topics
- docker: add missing vulkan library to base layer and update to 24.04 (#11422)
- docker: fix ARM build and Vulkan build (#11434)
- docker: add perplexity and bench commands to full image (#11438)
- docker: allow installing pip packages system-wide (#11437)

### Other
- mmap: fix fileno macro clash (#11076)
- tokenize: escape the prompt (#11058)
- github: add cmd line field to bug report (#11090)
- Disable GL_KHR_cooperative_matrix Vulkan extension if not available. (#11117)
- arg: option to exclude arguments from specific examples (#11136)
- sync: ggml
- lora: improve compat with `mergekit-extract-lora` (#11131)
- Enhance user input handling for llama-run (#11138)
- media: remove old img [no ci]
- examples: add README.md to tts example [no ci] (#11155)
- Reset color before we exit (#11205)
- contrib: add naming guidelines (#11177)
- contrib: add naming guidelines (cont) (#11177)
- contrib: add naming guidelines (cont) (#11177)
- cli: auto activate conversation mode if chat template is available (#11214)
- sync: ggml
- Refactor test-chat-template.cpp (#11224)
- vocab: add dummy tokens for "no_vocab" type (#11231)
- examples: add embd_to_audio to tts-outetts.py [no ci] (#11235)
- RoPE: fix back, CUDA support for back + noncont. (#11240)
- vocab: fix double-eos check (#11273)
- tts: add guide tokens support (#11186)
- Adding linenoise.cpp to llama-run (#11252)
- simple-chat: fix BOS being added to each message (#11278)
- cont: fix whitespaces (#11305)
- mmap: add include for cerrno (#11296)
- examples: fix add_special conditions (#11311)
- linenoise.cpp refactoring (#11301)
- export-lora: fix tok_embd tensor (#11330)
- Add Jinja template support (#11016)
- `common`: utils to split / join / repeat strings (from json converter) (#11342)
- Adding logprobs to /v1/completions (#11344)
- `minja`: sync at https://github.com/google/minja/commit/0f5f7f2b3770eb682fbc11763266d45204173686 (#11352)
- main: update README documentation for batch size (#11353)
- Treat hf.co/ prefix the same as hf: // (#11350)
- Add -ngl (#11372)
- Update documentation (#11373)
- Update llama-run README.md (#11386)
- CPU/CUDA: fix (GQA) mul mat back, add CUDA support (#11380)
- release: pack /lib in the packages (#11392)
- rocBLAS: Avoid fp32->fp16->fp32 conversion on cdna (#11356)
- hip: Add hipGraph and VMM support to ROCM (#11362)
- CANN: Add Ascend CANN build ci (#10217)
- Hip: disable VMM on hip as it seams that it dosent work in some configurations (#11420)
- AMD: parse the architecture as supplied by gcnArchName (#11244)
- Add new hf protocol for ollama (#11449)
- Handle missing model in CLI parameters for llama-run (#11399)
- Add github protocol pulling and http: // (#11465)
- HIP: Only call rocblas_initialize on rocblas versions with the multiple instantation bug (#11080)

## Important File Changes

### CMakeLists.txt
Status: modified | +57/-42

### convert_lora_to_gguf.py
Status: modified | +31/-3

### ggml/src/ggml-cpu/ggml-cpu.c
Status: modified | +331/-62

### ggml/src/ggml-metal/ggml-metal.m
Status: modified | +125/-19

### gguf-py/pyproject.toml
Status: modified | +0/-0

### tests/test-backend-ops.cpp
Status: modified | +0/-0

