### PR TITLE
update to b6358

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
 # enable CUDA build - not yet supported on PBP
 # build_env_vars:
 #  ANACONDA_ROCKET_ENABLE_CUDA: 1
-
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/sentencepiece-feedstock/pr9/c1621ca

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,8 +4,3 @@ build_parameters:
   - "--skip-existing"
   - "--error-overlinking"
   - "--variants \"{skip_cuda_prefect: True}\""
-
-# Required for glibc >= 2.28
-pkg_build_image_tag: main-rockylinux-8
-build_env_vars:
-  ANACONDA_ROCKET_GLIBC: "2.28"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,6 @@
-# disable CUDA build by default - not yet supported on PBP
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_CUDA: 0
+# enable CUDA build - not yet supported on PBP
+# build_env_vars:
+#  ANACONDA_ROCKET_ENABLE_CUDA: 1
 
 channels:
   - https://staging.continuum.io/pbp/fs/sentencepiece-feedstock/pr9/21ae2c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,4 @@
 #  ANACONDA_ROCKET_ENABLE_CUDA: 1
 
 channels:
-  - https://staging.continuum.io/pbp/fs/sentencepiece-feedstock/pr9/21ae2c4
+  - https://staging.continuum.io/preprod-pbp/fs/sentencepiece-feedstock/pr9/c1621ca

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-# the conda build parameters to use
-build_parameters:
-  - "--suppress-variables"
-  - "--skip-existing"
-  - "--error-overlinking"
-  - "--variants \"{skip_cuda_prefect: True}\""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
+# disable CUDA build by default - not yet supported on PBP
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_CUDA: 0
+
 channels:
   - https://staging.continuum.io/pbp/fs/sentencepiece-feedstock/pr9/21ae2c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/sentencepiece-feedstock/pr9/21ae2c4

--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -68,7 +68,7 @@ if errorlevel 1 exit 1
 cmake --install build
 if errorlevel 1 exit 1
 
-if "%PKG_NAME%" == "llama-cpp-tests" (
+if "%PKG_NAME%" == "llama.cpp-tests" (
     pushd build
     REM test-tokenizers-ggml-vocabs requires git-lfs to download the model files
     ctest -L main -C Release --output-on-failure -j%CPU_COUNT% --timeout 900 -E "test-tokenizers-ggml-vocabs"

--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -29,10 +29,25 @@ if "%blas_impl%"=="mkl" (
 REM LLAMA build options
 set LLAMA_ARGS=-DLLAMA_BUILD_NUMBER=%LLAMA_BUILD_NUMBER% -DLLAMA_BUILD_COMMIT=%LLAMA_BUILD_COMMIT%
 set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_CURL=ON
-set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_SERVER=ON
-set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TOOLS=ON
-set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TESTS=ON
-set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_EXAMPLES=OFF
+if "%PKG_NAME%" == "libllama" (
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_SERVER=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TOOLS=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TESTS=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_EXAMPLES=OFF
+) else if "%PKG_NAME%" == "llama.cpp" (
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_SERVER=ON
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TOOLS=ON
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TESTS=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_EXAMPLES=OFF
+) else if "%PKG_NAME%" == "llama.cpp-tests" (
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_SERVER=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TOOLS=OFF
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TESTS=ON
+    set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_EXAMPLES=OFF
+) else (
+    echo "Invalid package name: %PKG_NAME%"
+    exit 1
+)
 REM TODO add LLAMA_LLGUIDANCE?
 REM TODO set LLAMA_USE_SYSTEM_GGML once ggml gets its own feedstock
 
@@ -53,8 +68,10 @@ if errorlevel 1 exit 1
 cmake --install build
 if errorlevel 1 exit 1
 
-pushd build
-REM test-tokenizers-ggml-vocabs requires git-lfs to download the model files
-ctest -L main -C Release --output-on-failure -j%CPU_COUNT% --timeout 900 -E "test-tokenizers-ggml-vocabs"
-if errorlevel 1 exit 1
-popd
+if "%PKG_NAME%" == "llama-cpp-tests" (
+    pushd build
+    REM test-tokenizers-ggml-vocabs requires git-lfs to download the model files
+    ctest -L main -C Release --output-on-failure -j%CPU_COUNT% --timeout 900 -E "test-tokenizers-ggml-vocabs"
+    if errorlevel 1 exit 1
+    popd
+)

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -ex
 
+# workaround to get PBP to see that OSX_SDK_DIR is used
+# and thus get it forwarded to the build
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo $OSX_SDK_DIR
+fi
+
 # GGML build options
 GGML_ARGS="-DGGML_NATIVE=OFF -DGGML_CPU_ALL_VARIANTS=ON -DGGML_BACKEND_DL=ON"
 

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -69,7 +69,7 @@ fi
 # TODO add LLAMA_LLGUIDANCE? 
 # TODO set LLAMA_USE_SYSTEM_GGML once ggml gets its own feedstock
 
-cmake -S . -B build \
+cmake -S . -B build_${gpu_variant} \
     -G Ninja \
     ${CMAKE_ARGS} \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
@@ -79,15 +79,15 @@ cmake -S . -B build \
     ${GGML_ARGS} \
     ${LLAMA_ARGS}
 
-cmake --build build --config Release --verbose
-cmake --install build
+cmake --build build_${gpu_variant} --config Release --verbose
+cmake --install build_${gpu_variant}
  
 if [[ "$PKG_NAME" == "llama-cpp-tests" ]]; then
     # Tests like test_chat use relative paths to load the model template files that break when run from a different 
     # parent directory. Tests (per upstream CI workflows) should be run from the build directory.
     # See: https://github.com/ggerganov/llama.cpp/blob/master/.github/workflows/build.yml
 
-    pushd build
+    pushd build_${gpu_variant}
     # test-tokenizers-ggml-vocabs requires git-lfs to download the model files
     ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
     popd

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -88,7 +88,7 @@ cmake -S . -B build_${gpu_variant} \
 cmake --build build_${gpu_variant} --config Release --verbose
 cmake --install build_${gpu_variant}
  
-if [[ "$PKG_NAME" == "llama-cpp-tests" ]]; then
+if [[ "$PKG_NAME" == "llama.cpp-tests" ]]; then
     # Tests like test_chat use relative paths to load the model template files that break when run from a different 
     # parent directory. Tests (per upstream CI workflows) should be run from the build directory.
     # See: https://github.com/ggerganov/llama.cpp/blob/master/.github/workflows/build.yml

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,11 @@
+# This feedstocks builds two sets of packages:
+# - libllama, llama.cpp, llama.cpp-tests
+# - gguf, llama.cpp-tools
+# This helps us avoid mixing the two sets of packages in the same build on PBP.
+output_set:
+  - llama
+  - llama_cpp_tools
+
 c_compiler:        # [win]
   - vs2022         # [win]
 c_stdlib_version:  # [win]
@@ -6,24 +14,24 @@ cxx_compiler:      # [win]
   - vs2022         # [win]
 
 blas_impl:
-  - mkl                        # [(x86 or x86_64) and not osx]
-  - openblas                   # [not win and not osx]
+  - mkl                        # [win or (linux and x86_64)]
+  - openblas                   # [linux]
   - accelerate                 # [osx]
-  - cublas                     # [win or (linux and x86_64)]
+  - cublas                     # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
 
 gpu_variant:
   - none
-  - metal                      # [osx and arm64]
-  - cuda-12                    # [win or (linux and x86_64)]
+  - metal                      # [osx]
+  - cuda-12                    # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
 
-cuda_compiler_version:         # [win or (linux and x86_64)]
-  - none                       # [win or (linux and x86_64)]
-  - 12.4                       # [win or (linux and x86_64)]
+cuda_compiler_version:         # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+  - none                       # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+  - 12.4                       # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
 
-cuda_compiler:                 # [win or (linux and x86_64)]
-- cuda-nvcc                    # [win or (linux and x86_64)]
+cuda_compiler:                 # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+- cuda-nvcc                    # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
 
-zip_keys:                      # [win or (linux and x86_64)]
-  -                            # [win or (linux and x86_64)]
-    - gpu_variant              # [win or (linux and x86_64)]
-    - cuda_compiler_version    # [win or (linux and x86_64)]
+zip_keys:                      # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+  -                            # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+    - gpu_variant              # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
+    - cuda_compiler_version    # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,11 +5,6 @@ c_stdlib_version:  # [win]
 cxx_compiler:      # [win]
   - vs2022         # [win]
 
-c_compiler_version:   # [osx]
-  - 17                # [osx]
-cxx_compiler_version: # [osx]
-  - 17                # [osx]
-
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas                   # [not win and not osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -24,6 +24,15 @@ gpu_variant:
   - metal                      # [osx]
   - cuda-12                    # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
 
+# metal builds now require the MTLBuffer gpuAddress property, introduced in macOS 13.0
+c_stdlib_version:              # [osx]
+  - 12.1                       # [osx]
+  - 13.1                       # [osx]
+zip_keys:                      # [osx]
+  -                            # [osx]
+    - gpu_variant              # [osx]
+    - c_stdlib_version         # [osx]
+
 cuda_compiler_version:         # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
   - none                       # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]
   - 12.4                       # [ANACONDA_ROCKET_ENABLE_CUDA and (win or (linux and x86_64))]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b6358" %}
-{% set upstream_commit = "5aa1105da24a8dd1661cea3db0582c9b2c2f54d3" %}
+{% set upstream_release = "b6440" %}
+{% set upstream_commit = "33daece86b65607451d0d4378d2d04ba6a20ad55" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: 9cd9349fd664adfd6a6c8edcfc32ab9a6c624de68f58c7e2d377a0b3ef54e7f4
+  sha256: 7df8684c4d2e2b683855d2e199acaa559a2a81fd8ee9b0e47ed3e91c23dac3d0
 
   patches:
     - patches/mkl.patch                     # [blas_impl == "mkl"]
@@ -266,13 +266,13 @@ outputs:
         # requirements/requirements-convert_legacy_llama.txt
         - numpy >=1.26.4 # loosen bounds to accept numpy 2, which appears to be compatible
         - sentencepiece >=0.1.98,<=0.2.0
-        - transformers >=4.45.1,<5.0.0
+        - transformers >=4.51.3,<5.0.0
         - protobuf >=4.21.0,<5.0.0
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt
         # requirements/requirements-convert_lora_to_gguf.txt
         - mistral-common >=1.8.3
-        - pytorch >=2.4.0
+        - pytorch >=2.6.0
         - {{ pin_subpackage('gguf', exact=True) }}
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,14 +7,14 @@
 
 # When output_set is llama_cpp_tools, PBP trips on undefined variables
 # because they are not part of the variant config.
-# So we set them to -1 to avoid the render error.
-# Setting to -1 is safe because if they ever get used in the build, they
+# So we set them to 999.0a0 to avoid the render error.
+# Setting to 999.0a0 is safe because if they ever get used in the build, they
 # will generate a solve error.
 {% if output_set == "llama_cpp_tools" %}
-{% set libcurl = "-1" %}
-{% set mkl = "-1" %}
-{% set openblas = "-1" %}
-{% set cuda_compiler_version = "-1" %}
+{% set libcurl = "999.0a0" %}
+{% set mkl = "999.0a0" %}
+{% set openblas = "999.0a0" %}
+{% set cuda_compiler_version = "999.0a0" %}
 {% endif %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set upstream_commit = "5aa1105da24a8dd1661cea3db0582c9b2c2f54d3" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
-{% set build_number = 2 %}
+{% set build_number = 0 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,7 @@ source:
     - patches/fix-models-path.patch
 
 build:
-  # build with --variants "{enable_cuda: True}" to enable CUDA
-  skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
-  number: {{ build_number }} # trigger
+  number: {{ build_number }}
 
 outputs:
   - name: libllama
@@ -36,9 +34,8 @@ outputs:
     build:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
-        - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # build with --variants "{enable_cuda: True}" to enable CUDA
-      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
+        - LLAMA_BUILD_COMMIT={{ upstream_commit}}
+      skip: true # [output_set != "llama"]
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU
@@ -72,7 +69,7 @@ outputs:
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp 17.0.6                                  # [osx]
-        - libcurl {{ libcurl }}
+        - libcurl 
       run:
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
@@ -108,9 +105,8 @@ outputs:
     build:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
-        - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # build with --variants "{enable_cuda: True}" to enable CUDA
-      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
+        - LLAMA_BUILD_COMMIT={{ upstream_commit}}
+      skip: true # [output_set != "llama"]
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU
@@ -144,7 +140,7 @@ outputs:
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp 17.0.6                                  # [osx]
-        - libcurl {{ libcurl }}
+        - libcurl 
         - {{ pin_subpackage('libllama', exact=True) }}
       run:
         - {{ pin_subpackage('libllama', exact=True) }}
@@ -182,9 +178,8 @@ outputs:
     build:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
-        - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # build with --variants "{enable_cuda: True}" to enable CUDA
-      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
+        - LLAMA_BUILD_COMMIT={{ upstream_commit}}
+      skip: true # [output_set != "llama"] 
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU
@@ -215,7 +210,7 @@ outputs:
         - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - libcurl {{ libcurl }}
+        - libcurl 
         - {{ pin_subpackage('libllama', exact=True) }}
         - {{ pin_subpackage('llama.cpp', exact=True) }}
       run:
@@ -253,6 +248,7 @@ outputs:
         - llama-convert-llama-ggml-to-gguf = llama_cpp_tools.convert_llama_ggml_to_gguf:main
         - llama-convert-lora-to-gguf = llama_cpp_tools.convert_lora_to_gguf:main
       skip: True # [py<39]
+      skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 
     requirements:
@@ -315,8 +311,9 @@ outputs:
         - gguf-dump = gguf.scripts.gguf_dump:main
         - gguf-set-metadata = gguf.scripts.gguf_set_metadata:main
         - gguf-new-metadata = gguf.scripts.gguf_new_metadata:main
-        - gguf-editor-gui = gguf.scripts.gguf_editor_gui:main
+        - gguf-editor-gui = gguf.scripts.gguf_editor_gui:main      
       skip: True # [py<39]
+      skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -268,7 +268,7 @@ outputs:
         - numpy >=1.26.4 # loosen bounds to accept numpy 2, which appears to be compatible
         - sentencepiece >=0.1.98,<=0.2.0
         - transformers >=4.51.3,<5.0.0
-        - protobuf >=4.21.0,<5.0.0
+        - protobuf >=4.21.0,<6.0.0 # loosen bounds to accept protobuf 5
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt
         # requirements/requirements-convert_lora_to_gguf.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b6082" %}
+{% set upstream_release = "b6358" %}
 {% set upstream_commit = "5aa1105da24a8dd1661cea3db0582c9b2c2f54d3" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: f961d6a9525133991a0b86cce8e33671cac6b028d51f8d22ce2370b526f4c6c2
+  sha256: 9cd9349fd664adfd6a6c8edcfc32ab9a6c624de68f58c7e2d377a0b3ef54e7f4
 
   patches:
     - patches/mkl.patch                     # [blas_impl == "mkl"]
@@ -272,7 +272,7 @@ outputs:
         # requirements/requirements-convert_llama_ggml_to_gguf.txt
         # requirements/requirements-convert_lora_to_gguf.txt
         - mistral-common >=1.8.3
-        - pytorch >=2.2.1
+        - pytorch >=2.4.0
         - {{ pin_subpackage('gguf', exact=True) }}
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b6548" %}
-{% set upstream_commit = "37a23c17bdc9c99c9c6ad41168e4ced3724b72cd" %}
+{% set upstream_release = "b6500" %}
+{% set upstream_commit = "a7a98e0fffed794396b3fbad4dcdbbc184963645" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -23,7 +23,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: 3887acebcc5a3b9998da7f6b1e7a0fbba0adbf1176c6302043d36a6767c9337b
+  sha256: f2a188b194f25178460eecda7a7619b34d0b53421588faa2e6f0287a96674f28
 
   patches:
     - patches/mkl.patch                     # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,6 +87,8 @@ outputs:
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
+        - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
         - libcurl # bounds through run_exports
 
     test:
@@ -160,6 +162,8 @@ outputs:
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
+        - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
         - libcurl # bounds through run_exports
 
     test:
@@ -231,6 +235,8 @@ outputs:
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - _openmp_mutex                                       # [linux]
+        - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
         - libcurl # bounds through run_exports
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
 build:
   # build with --variants "{enable_cuda: True}" to enable CUDA
   skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
-  number: {{ build_number }}
+  number: {{ build_number }} # trigger
 
 outputs:
   - name: libllama

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b6500" %}
-{% set upstream_commit = "a7a98e0fffed794396b3fbad4dcdbbc184963645" %}
+{% set upstream_release = "b6548" %}
+{% set upstream_commit = "37a23c17bdc9c99c9c6ad41168e4ced3724b72cd" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -23,7 +23,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: f2a188b194f25178460eecda7a7619b34d0b53421588faa2e6f0287a96674f28
+  sha256: 3887acebcc5a3b9998da7f6b1e7a0fbba0adbf1176c6302043d36a6767c9337b
 
   patches:
     - patches/mkl.patch                     # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,6 +5,18 @@
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
 {% set build_number = 0 %}
 
+# When output_set is llama_cpp_tools, PBP trips on undefined variables
+# because they are not part of the variant config.
+# So we set them to -1 to avoid the render error.
+# Setting to -1 is safe because if they ever get used in the build, they
+# will generate a solve error.
+{% if output_set == "llama_cpp_tools" %}
+{% set libcurl = "-1" %}
+{% set mkl = "-1" %}
+{% set openblas = "-1" %}
+{% set cuda_compiler_version = "-1" %}
+{% endif %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -69,7 +81,7 @@ outputs:
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp 17.0.6                                  # [osx]
-        - libcurl 
+        - libcurl {{ libcurl }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
@@ -140,7 +152,7 @@ outputs:
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - llvm-openmp 17.0.6                                  # [osx]
-        - libcurl 
+        - libcurl {{ libcurl }}
         - {{ pin_subpackage('libllama', exact=True) }}
       run:
         - {{ pin_subpackage('libllama', exact=True) }}
@@ -210,7 +222,7 @@ outputs:
         - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - libcurl 
+        - libcurl {{ libcurl }}
         - {{ pin_subpackage('libllama', exact=True) }}
         - {{ pin_subpackage('llama.cpp', exact=True) }}
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b6440" %}
-{% set upstream_commit = "33daece86b65607451d0d4378d2d04ba6a20ad55" %}
+{% set upstream_release = "b6500" %}
+{% set upstream_commit = "a7a98e0fffed794396b3fbad4dcdbbc184963645" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -23,7 +23,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: 7df8684c4d2e2b683855d2e199acaa559a2a81fd8ee9b0e47ed3e91c23dac3d0
+  sha256: f2a188b194f25178460eecda7a7619b34d0b53421588faa2e6f0287a96674f28
 
   patches:
     - patches/mkl.patch                     # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,8 @@ source:
     - patches/fix-models-path.patch
 
 build:
-  skip: true # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
+  # build with --variants "{enable_cuda: True}" to enable CUDA
+  skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
   number: {{ build_number }}
 
 outputs:
@@ -36,8 +37,8 @@ outputs:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
         - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # skip_cuda_prefect is set through abs.yaml for use in prefect only
-      skip: true # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
+      # build with --variants "{enable_cuda: True}" to enable CUDA
+      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU
@@ -108,8 +109,8 @@ outputs:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
         - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # skip_cuda_prefect is set through abs.yaml for use in prefect only
-      skip: true # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
+      # build with --variants "{enable_cuda: True}" to enable CUDA
+      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU
@@ -182,8 +183,8 @@ outputs:
       script_env:
         - LLAMA_BUILD_NUMBER={{ upstream_release[1:] }}
         - LLAMA_BUILD_COMMIT={{ upstream_commit}}  
-      # skip_cuda_prefect is set through abs.yaml for use in prefect only
-      skip: true # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
+      # build with --variants "{enable_cuda: True}" to enable CUDA
+      skip: true # [not enable_cuda and (gpu_variant or "").startswith('cuda')]
       # do not mix cublas and mkl/openblas
       skip: true # [((gpu_variant or "").startswith('cuda') and (blas_impl != "cublas")) or (not (gpu_variant or "").startswith('cuda') and (blas_impl == "cublas"))]
       # Use a build number difference to ensure that the GPU

--- a/recipe/patches/metal_gpu_selection.patch
+++ b/recipe/patches/metal_gpu_selection.patch
@@ -1,6 +1,6 @@
-From aaf1a25c65647aec4c6fd583582d324392bff1ef Mon Sep 17 00:00:00 2001
+From a7a44342a7becf02a3bf640a022f9edaa5a3f3ce Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
-Date: Sun, 20 Jul 2025 14:03:26 -0400
+Date: Mon, 22 Sep 2025 10:36:54 -0400
 Subject: [PATCH] metal gpu selection
 
 In macOS, in order for the system to provide a default Metal device object, you must link to the Core Graphics framework. 
@@ -11,18 +11,18 @@ https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discu
 
 I did try linking to CoreGraphics, but MTLCreateSystemDefaultDevice was still returning nil.
 ---
- ggml/src/ggml-metal/ggml-metal.m | 19 +++++++++++++++++++
+ ggml/src/ggml-metal/ggml-metal-device.m | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
-diff --git a/ggml/src/ggml-metal/ggml-metal.m b/ggml/src/ggml-metal/ggml-metal.m
-index dc391a0d4..2083e2a31 100644
---- a/ggml/src/ggml-metal/ggml-metal.m
-+++ b/ggml/src/ggml-metal/ggml-metal.m
-@@ -92,6 +92,25 @@
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index 67f71ace2..beae781b8 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -449,6 +449,25 @@ ggml_metal_device_t ggml_metal_device_init(void) {
  
-     if (ctx->mtl_device == nil) {
-         ctx->mtl_device = MTLCreateSystemDefaultDevice();
-+        if (ctx->mtl_device == nil) {
+     if (dev->mtl_device == nil) {
+         dev->mtl_device = MTLCreateSystemDefaultDevice();
++        if (dev->mtl_device == nil) {
 +          /*
 +            In macOS, in order for the system to provide a default Metal device object, you must link to the Core Graphics framework.
 +            You usually need to do this explicitly if you're writing apps that don't use graphics by default, such as command line tools.
@@ -31,19 +31,19 @@ index dc391a0d4..2083e2a31 100644
 +            > https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discussion
 +           */
 +            NSArray * devices = MTLCopyAllDevices();
-+            for (id<MTLDevice> dev in devices) {
-+                if (dev != nil) {
-+                    if (ctx->mtl_device == nil) {
-+                        ctx->mtl_device = dev;
++            for (id<MTLDevice> device in devices) {
++                if (device != nil) {
++                    if (dev->mtl_device == nil) {
++                        dev->mtl_device = device;
 +                    } else {
-+                        [dev release];
++                        [device release];
 +                    }
 +                }
 +            }
 +        }
  
-         ctx->has_simdgroup_reduction  = [ctx->mtl_device supportsFamily:MTLGPUFamilyApple7];
-         ctx->has_simdgroup_reduction |= [ctx->mtl_device supportsFamily:MTLGPUFamilyMetal3_GGML];
+         if (dev->mtl_device) {
+             dev->mtl_queue = [dev->mtl_device newCommandQueue];
 -- 
 2.39.5 (Apple Git-154)
 

--- a/recipe/patches/metal_gpu_selection.patch
+++ b/recipe/patches/metal_gpu_selection.patch
@@ -1,6 +1,6 @@
-From a7a44342a7becf02a3bf640a022f9edaa5a3f3ce Mon Sep 17 00:00:00 2001
+From aaf1a25c65647aec4c6fd583582d324392bff1ef Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
-Date: Mon, 22 Sep 2025 10:36:54 -0400
+Date: Sun, 20 Jul 2025 14:03:26 -0400
 Subject: [PATCH] metal gpu selection
 
 In macOS, in order for the system to provide a default Metal device object, you must link to the Core Graphics framework. 
@@ -11,18 +11,18 @@ https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discu
 
 I did try linking to CoreGraphics, but MTLCreateSystemDefaultDevice was still returning nil.
 ---
- ggml/src/ggml-metal/ggml-metal-device.m | 19 +++++++++++++++++++
+ ggml/src/ggml-metal/ggml-metal.m | 19 +++++++++++++++++++
  1 file changed, 19 insertions(+)
 
-diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
-index 67f71ace2..beae781b8 100644
---- a/ggml/src/ggml-metal/ggml-metal-device.m
-+++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -449,6 +449,25 @@ ggml_metal_device_t ggml_metal_device_init(void) {
+diff --git a/ggml/src/ggml-metal/ggml-metal.m b/ggml/src/ggml-metal/ggml-metal.m
+index dc391a0d4..2083e2a31 100644
+--- a/ggml/src/ggml-metal/ggml-metal.m
++++ b/ggml/src/ggml-metal/ggml-metal.m
+@@ -92,6 +92,25 @@
  
-     if (dev->mtl_device == nil) {
-         dev->mtl_device = MTLCreateSystemDefaultDevice();
-+        if (dev->mtl_device == nil) {
+     if (ctx->mtl_device == nil) {
+         ctx->mtl_device = MTLCreateSystemDefaultDevice();
++        if (ctx->mtl_device == nil) {
 +          /*
 +            In macOS, in order for the system to provide a default Metal device object, you must link to the Core Graphics framework.
 +            You usually need to do this explicitly if you're writing apps that don't use graphics by default, such as command line tools.
@@ -31,19 +31,19 @@ index 67f71ace2..beae781b8 100644
 +            > https://developer.apple.com/documentation/metal/mtldevice/1433409-lowpower#discussion
 +           */
 +            NSArray * devices = MTLCopyAllDevices();
-+            for (id<MTLDevice> device in devices) {
-+                if (device != nil) {
-+                    if (dev->mtl_device == nil) {
-+                        dev->mtl_device = device;
++            for (id<MTLDevice> dev in devices) {
++                if (dev != nil) {
++                    if (ctx->mtl_device == nil) {
++                        ctx->mtl_device = dev;
 +                    } else {
-+                        [device release];
++                        [dev release];
 +                    }
 +                }
 +            }
 +        }
  
-         if (dev->mtl_device) {
-             dev->mtl_queue = [dev->mtl_device newCommandQueue];
+         ctx->has_simdgroup_reduction  = [ctx->mtl_device supportsFamily:MTLGPUFamilyApple7];
+         ctx->has_simdgroup_reduction |= [ctx->mtl_device supportsFamily:MTLGPUFamilyMetal3_GGML];
 -- 
 2.39.5 (Apple Git-154)
 


### PR DESCRIPTION
llama.cpp b6500

**Destination channel:** main

### Links

- [PKG-8901](https://anaconda.atlassian.net/browse/PKG-8901)
- https://github.com/ggml-org/llama.cpp/tree/b6500

### Explanation of changes:

- Update to b6500

Not unvendoring ggml. The ggml project itself does not have releases at this moment. Rather, development happens in llama.cpp and whisper.cpp. Then changes are synced back to the ggml project. Once it becomes more stable, we should add a feedstock for ggml and set LLAMA_USE_SYSTEM_GGML in llama.cpp.

The lint error is due to pytorch having a run_export. But here it used as a python run dependency.

CUDA builds logs:
- [linux-64 cuda build log](404)
- [win-64 cuda build log](404)


[PKG-8401]: https://anaconda.atlassian.net/browse/PKG-8401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-8901]: https://anaconda.atlassian.net/browse/PKG-8901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ