### PR TITLE
PKG-9512: Add models directory to llama.cpp-tools and fix path resolution issue

### DIFF
--- a/recipe/bld-llama-cpp-tools.bat
+++ b/recipe/bld-llama-cpp-tools.bat
@@ -14,6 +14,10 @@ if errorlevel 1 exit 1
 copy convert_lora_to_gguf.py %SP_DIR%\llama_cpp_tools\
 if errorlevel 1 exit 1
 
+:: Copy the models directory and its contents
+xcopy models %SP_DIR%\llama_cpp_tools\models /E /I /Y
+if errorlevel 1 exit 1
+
 :: Create an __init__.py file to make it a proper Python package
 type nul > %SP_DIR%\llama_cpp_tools\__init__.py
 if errorlevel 1 exit 1

--- a/recipe/build-llama-cpp-tools.sh
+++ b/recipe/build-llama-cpp-tools.sh
@@ -6,5 +6,8 @@ cp convert_hf_to_gguf.py $SP_DIR/llama_cpp_tools/
 cp convert_llama_ggml_to_gguf.py $SP_DIR/llama_cpp_tools/
 cp convert_lora_to_gguf.py $SP_DIR/llama_cpp_tools/
 
+# Copy the models directory and its contents
+cp -r models $SP_DIR/llama_cpp_tools/
+
 # Create an __init__.py file to make it a proper Python package
 touch $SP_DIR/llama_cpp_tools/__init__.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set upstream_commit = "5aa1105da24a8dd1661cea3db0582c9b2c2f54d3" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.17.1." + upstream_release[1:] %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     - patches/no-armv9-support-gcc11.patch  # [linux and aarch64]
     - patches/increase-nmse-tolerance.patch # [win]
     - patches/fix-convert_lora_to_gguf.patch
+    - patches/fix-models-path.patch
 
 build:
   skip: true # [skip_cuda_prefect and (gpu_variant or "").startswith('cuda')]
@@ -281,6 +282,14 @@ outputs:
         - llama-convert-hf-to-gguf --help
         - llama-convert-llama-ggml-to-gguf --help
         - llama-convert-lora-to-gguf --help
+        - test -d $SP_DIR/llama_cpp_tools/models  # [unix]
+        - test -f $SP_DIR/llama_cpp_tools/models/ggml-vocab-llama-bpe.gguf  # [unix]
+        - test -d $SP_DIR/llama_cpp_tools/models/templates  # [unix]
+        - test -f $SP_DIR/llama_cpp_tools/models/templates/README.md  # [unix]
+        - if not exist %SP_DIR%\llama_cpp_tools\models exit 1  # [win]
+        - if not exist %SP_DIR%\llama_cpp_tools\models\ggml-vocab-llama-bpe.gguf exit 1  # [win]
+        - if not exist %SP_DIR%\llama_cpp_tools\models\templates exit 1  # [win]
+        - if not exist %SP_DIR%\llama_cpp_tools\models\templates\README.md exit 1  # [win]
       requires:
         - pip
 
@@ -288,7 +297,7 @@ outputs:
       home: https://github.com/ggml-org/llama.cpp
       summary: Scripts and conversion tools that ship with llama.cpp
       description: |
-        Scripts and conversion tools that ship with llama.cpp
+        Scripts and conversion tools that ship with llama.cpp, including model vocabulary files and templates
       license: MIT
       license_family: MIT
       license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -259,12 +259,6 @@ outputs:
         - python
         - poetry-core >=1.0.0
         - pip
-        - numpy >=1.26.4
-        - sentencepiece >=0.1.98,<=0.2.0
-        - transformers >=4.45.1,<5.0.0
-        - protobuf >=4.21.0,<5.0.0
-        - mistral-common >=1.8.3
-        - pytorch >=2.2.1
       run:
         # This is an aggregate of requirements from multiple files in the llama.cpp-tools repo, see:
         # https://github.com/ggml-org/llama.cpp/tree/master/requirements

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -259,6 +259,12 @@ outputs:
         - python
         - poetry-core >=1.0.0
         - pip
+        - numpy >=1.26.4
+        - sentencepiece >=0.1.98,<=0.2.0
+        - transformers >=4.45.1,<5.0.0
+        - protobuf >=4.21.0,<5.0.0
+        - mistral-common >=1.8.3
+        - pytorch >=2.2.1
       run:
         # This is an aggregate of requirements from multiple files in the llama.cpp-tools repo, see:
         # https://github.com/ggml-org/llama.cpp/tree/master/requirements

--- a/recipe/patches/fix-models-path.patch
+++ b/recipe/patches/fix-models-path.patch
@@ -1,0 +1,22 @@
+From 3ea0eac09703ea067e29c7460afd72c063a6b19f Mon Sep 17 00:00:00 2001
+From: John Noller <jnoller@anaconda.com>
+Date: Sun, 20 Jul 2025 14:37:44 -0400
+Subject: [PATCH] fix convert_hf_to_gguf.py
+
+convert_hf_to_gguf.py uses relative paths to the models directory that break when run from a different
+parent directory. When the models are installed in a conda package, the script needs to use
+Path(__file__).parent instead of sys.path[0] to correctly locate the models directory.
+
+---
+diff --git a/convert_hf_to_gguf.py b/convert_hf_to_gguf.py
+index 1234567..abcdefg 100644
+--- a/convert_hf_to_gguf.py
++++ b/convert_hf_to_gguf.py
+@@ -1114,7 +1114,7 @@ class LlamaModel:
+         special_vocab.add_to_gguf(self.gguf_writer)
+ 
+     def _set_vocab_builtin(self, model_name: Literal["gpt-neox", "llama-spm"], vocab_size: int):
+-        tokenizer_path = Path(sys.path[0]) / "models" / f"ggml-vocab-{model_name}.gguf"
++        tokenizer_path = Path(__file__).parent / "models" / f"ggml-vocab-{model_name}.gguf"
+         logger.warning(f"Using tokenizer from '{os.path.relpath(tokenizer_path, os.getcwd())}'")
+         vocab_reader = gguf.GGUFReader(tokenizer_path, "r")


### PR DESCRIPTION
llama.cpp-tools 0.0.6082 

**Destination channel:** defaults

### Links

- [AIC-13](https://anaconda.atlassian.net/browse/AIC-13) 
- [PKG-9512](https://anaconda.atlassian.net/browse/PKG-9512)
- [Upstream repository](https://github.com/ggml-org/llama.cpp)

### Explanation of changes:

- This fixes an issue identified in the AIC-13 PR (https://github.com/anaconda/ai-core/pull/1150#issuecomment-3239550879) where if a model does not have a valid tokenizer / vocab files the `convert_hf_to_gguf.py` script attempts to fall back to the projects included `/models` directory.
- This is a rebuild of the current version.
- The `/models` directory is now bundled into the llama_cpp_tool/ namespace.
- `convert_hf_to_gguf.py` updated to use the correct path for loading.


[AIC-13]: https://anaconda.atlassian.net/browse/AIC-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-9512]: https://anaconda.atlassian.net/browse/PKG-9512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ