### PR TITLE
Fix ctest path to avoid broken cmake package cache on macOS

### DIFF
--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -97,24 +97,28 @@ if [[ "$PKG_NAME" == "llama.cpp-tests" ]]; then
     pushd build_${gpu_variant}
     # test-tokenizers-ggml-vocabs requires git-lfs to download the model files
 
+    # Use explicit path to ctest to avoid picking up broken binary from package cache
+    # (cmake 4.1.2 on macOS has @rpath issue with libzstd)
+    CTEST_CMD="${BUILD_PREFIX}/bin/ctest"
+
     if [[ ${gpu_variant:-} = "metal" ]]; then
         # Skip Metal-specific failing tests:
         # test-tokenizers-ggml-vocabs: Known test data issue (#10290)
         # test-thread-safety: crashes with "Subprocess aborted" (investigating)
-        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-thread-safety)"
+        ${CTEST_CMD} -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-thread-safety)"
     elif [[ ${gpu_variant:0:5} = "cuda-" ]]; then
         # Check GPU compute capability - skip test-backend-ops on older GPUs (<=7.5)
         # T4 (SM 7.5) has limited shared memory causing Flash Attention crashes
         COMPUTE_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')
         if [[ -n "$COMPUTE_CAP" ]] && [[ "$COMPUTE_CAP" -le 75 ]]; then
             echo "GPU compute capability <= 7.5 detected, skipping test-backend-ops (shared memory limits)"
-            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-backend-ops)"
+            ${CTEST_CMD} -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-backend-ops)"
         else
-            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
+            ${CTEST_CMD} -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
         fi
     else
         # Skip test-tokenizers-ggml-vocabs on all platforms: Requires git-lfs to download model files
-        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
+        ${CTEST_CMD} -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
     fi
     popd
 fi


### PR DESCRIPTION
llama.cpp 0.0.7710

  **Destination channel:** defaults

  ### Links

  - [Upstream repository](https://github.com/ggml-org/llama.cpp)
  - [Failed graph](https://package-build.anaconda.com/v1/graph/de04729f-78b5-48b5-9805-97b0d96d0320)

  ### Explanation of changes:

  - cmake 4.1.2 package on macOS has this issue when ctest is picked up from `/private/var/folders/.../T/conda_pkgs_.../cmake-4.1.2.../bin/ctest` instead of the build environment
  - Error was: `dyld: Library not loaded: @rpath/libzstd.1.dylib`
  - This is a workaround for a PBP infrastructure issue with the cmake package
  
  
