### PR TITLE
Update to b8574

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,3 @@
 # and multiple CUDA variants (12.9, 13.0, 13.1)
 # Default is 7200 seconds (2 hours), which is insufficient
 task_timeout: 25200  # 7 hours
-
-# Upload to staging so llama-cpp-python can build before main release
-staging_channel_upload_target: llama-cpp-b8574-staging

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
 # Increase timeout for builds with GGML_CPU_ALL_VARIANTS=ON
 # which compiles 15 different CPU backend variants (x64 to sapphirerapids)
-# and multiple CUDA variants (12.8, 13.0, 13.1)
+# and multiple CUDA variants (12.9, 13.0, 13.1)
 # Default is 7200 seconds (2 hours), which is insufficient
-task_timeout: 25201  # 7 hours
+task_timeout: 25200  # 7 hours
+
+# Upload to staging so llama-cpp-python can build before main release
+staging_channel_upload_target: llama-cpp-b8574-staging

--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -73,8 +73,7 @@ if errorlevel 1 exit 1
 if "%PKG_NAME%" == "llama.cpp-tests" (
     pushd build
     REM test-tokenizers-ggml-vocabs requires git-lfs to download the model files
-    REM test-llama-archs: incompatible with GGML_BACKEND_DL=ON (requires statically linked backends)
-    ctest -L main -C Release --output-on-failure -j%CPU_COUNT% --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-llama-archs)"
+    ctest -L main -C Release --output-on-failure -j%CPU_COUNT% --timeout 900 -E "test-tokenizers-ggml-vocabs"
     if errorlevel 1 exit 1
     popd
 )

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -99,23 +99,21 @@ if [[ "$PKG_NAME" == "llama.cpp-tests" ]]; then
 
     if [[ ${gpu_variant:-} = "metal" ]]; then
         # test-tokenizers-ggml-vocabs: Requires git-lfs to download model files
-        # test-llama-archs: incompatible with GGML_BACKEND_DL=ON
         # test-thread-safety: GGML_ASSERT(buf_dst) fails in ggml_metal_cpy_tensor_async during concurrent decode
-        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-llama-archs|test-thread-safety)"
+        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-thread-safety)"
     elif [[ ${gpu_variant:0:5} = "cuda-" ]]; then
         # Check GPU compute capability - skip test-backend-ops on older GPUs (<=7.5)
         # T4 (SM 7.5) has limited shared memory causing Flash Attention crashes
         COMPUTE_CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')
         if [[ -n "$COMPUTE_CAP" ]] && [[ "$COMPUTE_CAP" -le 75 ]]; then
             echo "GPU compute capability <= 7.5 detected, skipping test-backend-ops (shared memory limits)"
-            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-backend-ops|test-llama-archs)"
+            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-backend-ops)"
         else
-            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-llama-archs)"
+            ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
         fi
     else
         # Skip test-tokenizers-ggml-vocabs on all platforms: Requires git-lfs to download model files
-        # Skip test-llama-archs: incompatible with GGML_BACKEND_DL=ON (requires statically linked backends)
-        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs|test-llama-archs)"
+        ctest -L main -C Release --output-on-failure -j${CPU_COUNT} --timeout 900 -E "(test-tokenizers-ggml-vocabs)"
     fi
     popd
 fi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -38,7 +38,7 @@ OSX_SDK_VER:                   # [osx]
 
 cuda_compiler_version:         # [win or linux]
   - none                       # [win or linux]
-  - 12.8                       # [win or linux]
+  - 12.9                       # [win or linux]
   - 13.0                       # [win or linux]
   - 13.1                       # [win or linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b8272" %}
-{% set upstream_commit = "1274fbee9e185d41447bf6edb739e7240c0319a2" %}
+{% set upstream_release = "b8533" %}
+{% set upstream_commit = "0fac87b157305eb82a70902327abffbbce25bd3e" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: b0af53f0b4007e4d0cf07b9f0cf80fa502547fef27761da2eb80c7a0a8480fc4
+  sha256: b119fff4ab3e87b093a77a1ec1af4541d4b3d0c2800d1f61925ad1a3c127ab3a
 
   patches:
     - patches/increase-nmse-tolerance.patch
@@ -32,6 +32,7 @@ source:
     - patches/disable-metal-flash-attention.patch  # [osx]
     - patches/fix-convert_lora_to_gguf.patch
     - patches/fix-models-path.patch
+    - patches/fix-test-llama-archs-backend-dl.patch
 
 build:
   number: {{ build_number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,7 @@ outputs:
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:
@@ -165,6 +166,7 @@ outputs:
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:
@@ -238,6 +240,7 @@ outputs:
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
+        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,6 @@ outputs:
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
-        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:
@@ -166,7 +165,6 @@ outputs:
         - llvm-openmp                                         # [osx] bounds through run_exports
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
-        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:
@@ -240,7 +238,6 @@ outputs:
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - _openmp_mutex                                       # [linux]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
-        - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b8533" %}
-{% set upstream_commit = "0fac87b157305eb82a70902327abffbbce25bd3e" %}
+{% set upstream_release = "b8574" %}
+{% set upstream_commit = "98ae0a0d3600f08fbd8d938bc8de0436755e50c3" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: b119fff4ab3e87b093a77a1ec1af4541d4b3d0c2800d1f61925ad1a3c127ab3a
+  sha256: f1a4e4a57bc7e31e3549e979fe7c6553dfd249958b8dfe6f63f698cac7682c75
 
   patches:
     - patches/increase-nmse-tolerance.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -266,6 +266,7 @@ outputs:
         - llama-convert-llama-ggml-to-gguf = llama_cpp_tools.convert_llama_ggml_to_gguf:main
         - llama-convert-lora-to-gguf = llama_cpp_tools.convert_lora_to_gguf:main
       skip: True # [py<39]
+      skip: true # [py>313]
       skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 
@@ -332,6 +333,7 @@ outputs:
         - gguf-new-metadata = gguf.scripts.gguf_new_metadata:main
         - gguf-editor-gui = gguf.scripts.gguf_editor_gui:main      
       skip: True # [py<39]
+      skip: true # [py>313]
       skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 

--- a/recipe/patches/fix-test-llama-archs-backend-dl.patch
+++ b/recipe/patches/fix-test-llama-archs-backend-dl.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xianglong Kong <xkong@anaconda.com>
+Subject: [PATCH] tests: fix test-llama-archs with GGML_BACKEND_DL=ON
+
+When building with GGML_BACKEND_DL=ON, backends are compiled as dynamic
+libraries and must be explicitly loaded at runtime. test-llama-archs was
+missing the ggml_backend_load_all() call, causing "no backends are loaded"
+failures.
+
+This matches the pattern used by test-backend-ops and test-opt.
+
+Upstream issue: https://github.com/ggml-org/llama.cpp/issues/20611
+
+---
+ tests/test-llama-archs.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/tests/test-llama-archs.cpp
++++ b/tests/test-llama-archs.cpp
+@@ -541,6 +541,7 @@ static int test_backends(const llm_arch
+ int main(int argc, char ** argv) {
+     // FIXME these tests are disabled in the CI for macOS-latest-cmake-arm64 because they are segfaulting
+     common_init();
++    ggml_backend_load_all();
+     std::random_device rd;
+
+     llm_arch arch = LLM_ARCH_UNKNOWN;


### PR DESCRIPTION
llama.cpp 0.0.8574

**Destination channel:** defaults

### Links

- [PKG-13108](https://anaconda.atlassian.net/browse/PKG-13108)
- [Upstream repository](https://github.com/ggml-org/llama.cpp)
- [Upstream changelog/diff](https://github.com/ggml-org/llama.cpp/compare/b8272...b8574)

### Explanation of changes:

- Update llama.cpp from b8272 to b8574 (302 commits)
- Bump CUDA from 12.8 to 12.9 (now: 12.9, 13.0, 13.1)
- Add `fix-test-llama-archs-backend-dl.patch`: fixes upstream [#20611](https://github.com/ggml-org/llama.cpp/issues/20611) for `GGML_BACKEND_DL=ON` builds
- Re-enable `test-llama-archs` on all platforms (previously skipped, now fixed by patch)
- Skip py314 for llama.cpp-tools and gguf (transformers has no py314 build yet)

#### Notable upstream changes (b8272 → b8574):

**CUDA:**
- Native BF16 flash attention for vec kernel (#20525)
- Fix BF16 FA compilation (#20865)
- Increase output elements per-thread block for small K-dimension (#20635)
- Support F32 kernel type for CONV_TRANSPOSE_2D (#17094)

**Metal:**
- Flash attention for HSK=512, HSV=512 (#20902)
- CONV_3D support (#19927)
- FLOOR, CEIL, ROUND, TRUNC unary ops (#20930)

**Server:**
- Fix router mode deadlock on child crash (#20763)
- Fix Host header (#20843)

**Models:**
- BF16 and quantized type support (#20803)
- Mistral Small 4 support (#20649)
- DeepSeekOCR support (#17400)
- codefuse-ai/F2LLM-v2 support
- Control vector support where missing (#20653)

[PKG-13108]: https://anaconda.atlassian.net/browse/PKG-13108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ