### PR TITLE
Update llama.cpp from b8574 to b8728

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,3 @@
-# TEMPORARY — single-Python fast iteration. Remove before merge.
-python:
-  - "3.12"
-
 # This feedstocks builds two sets of packages:
 # - libllama, llama.cpp, llama.cpp-tests
 # - gguf, llama.cpp-tools

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -32,7 +32,6 @@ gpu_variant:
   - metal                      # [osx]
   - cuda-12                    # [win or linux]
   - cuda-13                    # [win or linux]
-  - cuda-13                    # [win or linux]
 
 # metal builds now require the MTLBuffer gpuAddress property, introduced in macOS 13.0
 # metal builds now require the MTLDataType.bfloat4 data type, introduced in macOS 14.0
@@ -43,7 +42,6 @@ OSX_SDK_VER:                   # [osx]
 cuda_compiler_version:         # [win or linux]
   - none                       # [win or linux]
   - 12.9                       # [win or linux]
-  - 13.0                       # [win or linux]
   - 13.1                       # [win or linux]
 
 zip_keys:                      # [win or linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,7 @@
+# TEMPORARY — single-Python fast iteration. Remove before merge.
+python:
+  - "3.12"
+
 # This feedstocks builds two sets of packages:
 # - libllama, llama.cpp, llama.cpp-tests
 # - gguf, llama.cpp-tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b8574" %}
-{% set upstream_commit = "98ae0a0d3600f08fbd8d938bc8de0436755e50c3" %}
+{% set upstream_release = "b8728" %}
+{% set upstream_commit = "5e9c6354638858f4c9aa0a70fd4a41a73f894dcc" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: f1a4e4a57bc7e31e3549e979fe7c6553dfd249958b8dfe6f63f698cac7682c75
+  sha256: 27351204528caf769eaf64b0498b160167df1559da23c277c7a8f7c840b38819
 
   patches:
     - patches/increase-nmse-tolerance.patch

--- a/recipe/patches/increase-nmse-tolerance-aarch64.patch
+++ b/recipe/patches/increase-nmse-tolerance-aarch64.patch
@@ -15,7 +15,7 @@ for architecture-specific precision differences.
 Applies on top of increase-nmse-tolerance.patch (5e-4 -> 5e-3).
 This patch further increases: 5e-3 -> 1e-1 for aarch64 only.
 
-Updated for b8272: Adjusted for new line numbers (9 instances).
+Updated for b8728: Adjusted for new line numbers (9 instances).
 
 ---
  tests/test-backend-ops.cpp | 18 +++++++++--------
@@ -25,7 +25,7 @@ diff --git a/tests/test-backend-ops.cpp b/tests/test-backend-ops.cpp
 index f5e6a7b8c..d7c8e9f0a 100644
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -3748,7 +3748,7 @@
+@@ -3760,7 +3760,7 @@
      }
 
      double max_nmse_err() override {
@@ -34,7 +34,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -3884,7 +3884,7 @@
+@@ -3896,7 +3896,7 @@
      }
 
      double max_nmse_err() override {
@@ -43,7 +43,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -3952,7 +3952,7 @@
+@@ -3964,7 +3964,7 @@
      }
 
      double max_nmse_err() override {
@@ -52,7 +52,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -4031,7 +4031,7 @@
+@@ -4043,7 +4043,7 @@
      }
 
      double max_nmse_err() override {
@@ -61,7 +61,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      test_out_prod(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
-@@ -4787,7 +4787,7 @@
+@@ -4802,7 +4802,7 @@
      }
 
      double max_nmse_err() override {
@@ -69,8 +69,8 @@ index f5e6a7b8c..d7c8e9f0a 100644
 +        return 1e-1; // The default 1e-7 is too small for Vulkan and ARM64 BLAS.
      }
 
-     test_conv_transpose_2d(std::array<int64_t, 4> ne_input = {10, 10, 3, 1}, // [input_width, input_height, input_channels, 1]
-@@ -4939,7 +4939,7 @@
+     test_conv_transpose_2d(
+@@ -4956,7 +4956,7 @@
      }
 
      double max_nmse_err() override {
@@ -79,7 +79,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5071,7 +5071,7 @@
+@@ -5088,7 +5088,7 @@
      }
 
      double max_nmse_err() override {
@@ -88,7 +88,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
 
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5576,7 +5576,7 @@
+@@ -5593,7 +5593,7 @@
      }
 
      double max_nmse_err() override {
@@ -97,7 +97,7 @@ index f5e6a7b8c..d7c8e9f0a 100644
      }
  };
 
-@@ -6142,7 +6142,7 @@
+@@ -6159,7 +6159,7 @@
      }
 
      double max_nmse_err() override {


### PR DESCRIPTION
llama.cpp 0.0.8728

**Destination channel:** defaults

### Links

- [PKG-13213](https://anaconda.atlassian.net/browse/PKG-13213)
- [Upstream repository](https://github.com/ggml-org/llama.cpp)
- [Upstream changelog/diff](https://github.com/ggml-org/llama.cpp/compare/b8574...b8728)

### Explanation of changes:

- **Version bump:** b8574 → b8728 
- **Upstream changes:** Model support additions (gguf constants, tensor mappings, vocab), convert_hf_to_gguf improvements, SYCL flash-attn support for head size 512, Metal mm-id specializations, server grammar fixes


[PKG-13213]: https://anaconda.atlassian.net/browse/PKG-13213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ