### PR TITLE
Add openblas variant on windows.

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -19,7 +19,7 @@ cxx_compiler:                      # [win]
 
 blas_impl:
   - mkl                        # [win or (linux and x86_64)]
-  - openblas                   # [linux]
+  - openblas                   # [win or linux]
   - accelerate                 # [osx]
   - cublas                     # [win or linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set upstream_commit = "5e9c6354638858f4c9aa0a70fd4a41a73f894dcc" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # When output_set is llama_cpp_tools, PBP trips on undefined variables
 # because they are not part of the variant config.


### PR DESCRIPTION
llama.cpp rebuild with openblas windows variant

**Destination channel:** defaults

### Links

- [PKG-13582](https://anaconda.atlassian.net/browse/PKG-13582) 

### Explanation of changes:

- Add openblas to windows build matrix
- Bump build number

[PKG-13582]: https://anaconda.atlassian.net/browse/PKG-13582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ