### PR TITLE
Prevent mixing openmp variants.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,3 @@
 # and multiple CUDA variants (12.9, 13.0)
 # Default is 7200 seconds (2 hours), which is insufficient
 task_timeout: 25200  # 7 hours
-
-channels:
- - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,6 @@
 # and multiple CUDA variants (12.9, 13.0)
 # Default is 7200 seconds (2 hours), which is insufficient
 task_timeout: 25200  # 7 hours
+
+channels:
+ - build

--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -3,6 +3,7 @@ setlocal EnableDelayedExpansion
 
 REM GGML build options
 set GGML_ARGS=-DGGML_NATIVE=OFF -DGGML_CPU_ALL_VARIANTS=ON -DGGML_BACKEND_DL=ON
+set GGML_OPENMP_FLAGS=
 
 if "%gpu_variant:~0,5%"=="cuda-" (
     REM Let llama.cpp's CMakeLists.txt handle architecture selection
@@ -17,6 +18,7 @@ if "%blas_impl%"=="mkl" (
     set GGML_ARGS=!GGML_ARGS! -DGGML_BLAS=ON
     set GGML_ARGS=!GGML_ARGS! -DGGML_ACCELERATE=OFF
     set GGML_ARGS=!GGML_ARGS! -DGGML_BLAS_VENDOR=Intel10_64_dyn
+    set GGML_OPENMP_FLAGS=-DOpenMP_C_FLAGS=/openmp:llvm -DOpenMP_CXX_FLAGS=/openmp:llvm -DOpenMP_C_LIB_NAMES=libiomp5md -DOpenMP_CXX_LIB_NAMES=libiomp5md -DOpenMP_libiomp5md_LIBRARY=%LIBRARY_LIB%\libiomp5md.lib
 ) else if "%blas_impl%"=="openblas" (
     set GGML_ARGS=!GGML_ARGS! -DGGML_BLAS=ON
     set GGML_ARGS=!GGML_ARGS! -DGGML_ACCELERATE=OFF
@@ -61,6 +63,7 @@ cmake -S . -B build ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DBUILD_SHARED_LIBS=ON  ^
     !GGML_ARGS! ^
+    !GGML_OPENMP_FLAGS! ^
     !LLAMA_ARGS!
 if errorlevel 1 exit 1
 

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -9,6 +9,7 @@ fi
 
 # GGML build options
 GGML_ARGS="-DGGML_NATIVE=OFF -DGGML_CPU_ALL_VARIANTS=ON -DGGML_BACKEND_DL=ON"
+GGML_OPENMP_FLAGS=()
 
 if [[ ${gpu_variant:0:5} = "cuda-" ]]; then
     # Let llama.cpp's CMakeLists.txt handle architecture selection
@@ -43,6 +44,15 @@ elif [[ ${blas_impl:-} = "mkl" ]]; then
     GGML_ARGS="${GGML_ARGS} -DGGML_BLAS=ON"
     GGML_ARGS="${GGML_ARGS} -DGGML_ACCELERATE=OFF"
     GGML_ARGS="${GGML_ARGS} -DGGML_BLAS_VENDOR=Intel10_64_dyn"
+    if [[ "${target_platform:-}" == linux-* ]]; then
+        GGML_OPENMP_FLAGS=(
+            -DOpenMP_C_FLAGS=-fopenmp
+            -DOpenMP_CXX_FLAGS=-fopenmp
+            -DOpenMP_C_LIB_NAMES=iomp5
+            -DOpenMP_CXX_LIB_NAMES=iomp5
+            -DOpenMP_iomp5_LIBRARY=${PREFIX}/lib/libiomp5${SHLIB_EXT}
+        )
+    fi
 elif [[ ${blas_impl:-} = "openblas" ]]; then
     GGML_ARGS="${GGML_ARGS} -DGGML_BLAS=ON"
     GGML_ARGS="${GGML_ARGS} -DGGML_ACCELERATE=OFF"
@@ -84,6 +94,7 @@ cmake -S . -B build_${gpu_variant} \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON  \
     ${GGML_ARGS} \
+    "${GGML_OPENMP_FLAGS[@]}" \
     ${LLAMA_ARGS}
 
 cmake --build build_${gpu_variant} --config Release --verbose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set upstream_commit = "aab68217b7bd8907135dd41fbb5bcb85fca06045" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # When output_set is llama_cpp_tools, PBP trips on undefined variables
 # because they are not part of the variant config.
@@ -83,17 +83,25 @@ outputs:
         - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - llvm-openmp 17.0.6                                  # [osx]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - llvm-openmp {{ cxx_compiler_version }}              # [osx and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - openssl
       run:
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - llvm-openmp                                         # [osx] bounds through run_exports
-        - _openmp_mutex                                       # [linux]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - llvm-openmp                                         # [osx and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
         - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
     test:
+      requires:
+        - c-compiler  # [win and blas_impl == "mkl"]
+      files:
+        - test-openmp.bat  # [win and blas_impl == "mkl"]
+        - test-openmp.sh  # [linux and blas_impl == "mkl"]
       commands:
         - test -f $PREFIX/include/llama.h    # [unix]
         - test -f $PREFIX/lib/libllama.so    # [linux]
@@ -101,6 +109,8 @@ outputs:
         - if not exist %PREFIX%/Library/include/llama.h exit 1  # [win]
         - if not exist %PREFIX%/Library/lib/llama.lib exit 1    # [win]
         - if not exist %PREFIX%/Library/bin/llama.dll exit 1    # [win]
+        - bash test-openmp.sh  # [linux and blas_impl == "mkl"]
+        - test-openmp.bat  # [win and blas_impl == "mkl"]
 
     about:
       home: https://github.com/ggml-org/llama.cpp
@@ -157,15 +167,18 @@ outputs:
         - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - llvm-openmp 17.0.6                                  # [osx]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - llvm-openmp {{ cxx_compiler_version }}              # [osx and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - openssl
         - {{ pin_subpackage('libllama', exact=True) }}
       run:
         - {{ pin_subpackage('libllama', exact=True) }}
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - llvm-openmp                                         # [osx] bounds through run_exports
-        - _openmp_mutex                                       # [linux]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - llvm-openmp                                         # [osx and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
         - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 
@@ -231,6 +244,8 @@ outputs:
         - openblas-devel {{ openblas }}                       # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "openblas"]
         - mkl-devel {{ mkl }}                                 # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
         - intel-openmp {{ mkl }}                              # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - openssl
         - {{ pin_subpackage('libllama', exact=True) }}
         - {{ pin_subpackage('llama.cpp', exact=True) }}
@@ -239,7 +254,8 @@ outputs:
         - {{ pin_subpackage('llama.cpp', exact=True) }}
         - {{ pin_compatible('cuda-version', max_pin='x.x') }} # [(gpu_variant or "").startswith('cuda')]
         - {{ pin_compatible('intel-openmp') }}                # [(not (gpu_variant or "").startswith('cuda')) and blas_impl == "mkl"]
-        - _openmp_mutex                                       # [linux]
+        - libgomp                                             # [linux and not (blas_impl == "mkl")]
+        - vcomp14                                             # [(win and x86_64) and not (blas_impl == "mkl")]
         - cuda-version     {{ cuda_compiler_version }}        # [(gpu_variant or "").startswith('cuda')]
         - __cuda                                              # [(gpu_variant or "").startswith('cuda')]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,17 @@ source:
 build:
   number: {{ build_number }}
 
+requirements:
+  build:
+    # Work-around for SIR-3252
+    - {{ stdlib('c')}}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}                              # [(gpu_variant or "").startswith('cuda')]
+    - cmake
+    - ninja-base
+    - pkgconfig
+
 outputs:
   - name: libllama
     script: build-llama-cpp.sh   # [not win]

--- a/recipe/test-openmp.bat
+++ b/recipe/test-openmp.bat
@@ -1,0 +1,16 @@
+@echo on
+setlocal enabledelayedexpansion
+
+set FOUND_IOMP=0
+
+for %%F in (%LIBRARY_BIN%\ggml*.dll %LIBRARY_BIN%\llama.dll) do (
+    if exist "%%~F" (
+        dumpbin /dependents "%%~F" | findstr /I "VCOMP libomp" && exit /B 1
+        dumpbin /dependents "%%~F" | findstr /I "libiomp5md.dll" && set FOUND_IOMP=1
+    )
+)
+
+if "!FOUND_IOMP!"=="1" exit /B 0
+
+echo libiomp5md.dll was not found in llama.cpp or ggml binary dependencies.
+exit /B 1

--- a/recipe/test-openmp.sh
+++ b/recipe/test-openmp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+found_iomp=0
+
+for lib in "${PREFIX}"/bin/libggml*.so "${PREFIX}"/lib/libggml*.so "${PREFIX}"/lib/libllama.so; do
+    if [[ -f "${lib}" ]]; then
+        if ldd "${lib}" | grep -Ei 'libgomp'; then
+            exit 1
+        fi
+
+        if ldd "${lib}" | grep -Ei 'libiomp5'; then
+            found_iomp=1
+        fi
+    fi
+done
+
+if [[ "${found_iomp}" == "1" ]]; then
+    exit 0
+fi
+
+echo "libiomp5 was not found in llama.cpp or ggml binary dependencies."
+exit 1


### PR DESCRIPTION
llama.cpp rebuild

**Destination channel:** defaults

### Links

- [PKG-14721](https://anaconda.atlassian.net/browse/PKG-14721) 


### Explanation of changes:

- Force mkl build to build with intel-openmp
    - Previously linux was linking with gnu and windows with msvc
    - Adds tests to ensure things are linking as anticipated 
- Bump build number
- Add build requirements to top level requirements. Fix for incorrect compiler versions being chosen (PBP work-around)
- Explicitly include the openmp variant used. 

[OpenMP Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)


[PKG-14721]: https://anaconda.atlassian.net/browse/PKG-14721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ