### PR TITLE
llama.cpp: update from b8994 to b9453

### DIFF
--- a/recipe/bld-llama-cpp-tools.bat
+++ b/recipe/bld-llama-cpp-tools.bat
@@ -14,6 +14,12 @@ if errorlevel 1 exit 1
 copy convert_lora_to_gguf.py %SP_DIR%\llama_cpp_tools\
 if errorlevel 1 exit 1
 
+:: Upstream b9445+ moved model definitions into a `conversion/` package;
+:: copy it under llama_cpp_tools/ so the redirected imports
+:: (`from llama_cpp_tools.conversion import ...`) resolve at runtime.
+xcopy conversion %SP_DIR%\llama_cpp_tools\conversion /E /I /Y
+if errorlevel 1 exit 1
+
 :: Copy the models directory and its contents
 xcopy models %SP_DIR%\llama_cpp_tools\models /E /I /Y
 if errorlevel 1 exit 1

--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -33,6 +33,11 @@ if "%blas_impl%"=="mkl" (
 REM LLAMA build options
 set LLAMA_ARGS=-DLLAMA_BUILD_NUMBER=%LLAMA_BUILD_NUMBER% -DLLAMA_BUILD_COMMIT=%LLAMA_BUILD_COMMIT%
 set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_OPENSSL=ON
+REM Disable the unified `llama` router app: it #includes common/build-info.h but
+REM the upstream app/CMakeLists.txt does not wire up its include path, so the
+REM build fails with "fatal error: build-info.h: No such file or directory".
+REM Upstream workaround documented in ggml-org/llama.cpp#23628.
+set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_APP=OFF
 if "%PKG_NAME%" == "libllama" (
     set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_SERVER=OFF
     set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_BUILD_TOOLS=OFF

--- a/recipe/build-llama-cpp-tools.sh
+++ b/recipe/build-llama-cpp-tools.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
+set -e
 
 # Create our package directory
 mkdir -p $SP_DIR/llama_cpp_tools
 cp convert_hf_to_gguf.py $SP_DIR/llama_cpp_tools/
 cp convert_llama_ggml_to_gguf.py $SP_DIR/llama_cpp_tools/
 cp convert_lora_to_gguf.py $SP_DIR/llama_cpp_tools/
+
+# Upstream b9445+ moved model definitions into a `conversion/` package; copy
+# it under llama_cpp_tools/ so the redirected imports
+# (`from llama_cpp_tools.conversion import ...`) resolve at runtime.
+cp -r conversion $SP_DIR/llama_cpp_tools/
 
 # Copy the models directory and its contents
 cp -r models $SP_DIR/llama_cpp_tools/

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -64,6 +64,11 @@ fi
 # LLAMA build options
 LLAMA_ARGS="-DLLAMA_BUILD_NUMBER=${LLAMA_BUILD_NUMBER} -DLLAMA_BUILD_COMMIT=${LLAMA_BUILD_COMMIT}"
 LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_OPENSSL=ON"
+# Disable the unified `llama` router app: it #includes common/build-info.h but the
+# upstream app/CMakeLists.txt does not wire up its include path, so the build fails
+# with `fatal error: build-info.h: No such file or directory` on every platform.
+# Upstream workaround documented in ggml-org/llama.cpp#23628.
+LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_BUILD_APP=OFF"
 if [[ "$PKG_NAME" == "libllama" ]]; then
     LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_BUILD_SERVER=OFF"
     LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_BUILD_TOOLS=OFF"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b8994" %}
-{% set upstream_commit = "aab68217b7bd8907135dd41fbb5bcb85fca06045" %}
+{% set upstream_release = "b9453" %}
+{% set upstream_commit = "48b88c3b0057fcf1171f8d62ff9f6b10de27a11e" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
-{% set build_number = 1 %}
+{% set build_number = 0 %}
 
 # When output_set is llama_cpp_tools, PBP trips on undefined variables
 # because they are not part of the variant config.
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: c0fb25d008add462488f65df59bcfad1806608034502feba7dc95216e05becfa
+  sha256: 3d755128d1b329c186a96e4a13f7b4fe1fe80067b6f21c56d742153bfc165e1a
 
   patches:
     - patches/increase-nmse-tolerance.patch
@@ -30,6 +30,7 @@ source:
     - patches/metal_gpu_selection.patch     # [osx]
     - patches/disable-metal-bf16.patch      # [osx]
     - patches/disable-metal-flash-attention.patch  # [osx]
+    - patches/fix-convert_hf_to_gguf.patch
     - patches/fix-convert_lora_to_gguf.patch
     - patches/fix-models-path.patch
     - patches/fix-test-llama-archs-backend-dl.patch
@@ -313,7 +314,9 @@ outputs:
         # requirements/requirements-convert_legacy_llama.txt
         - numpy >=1.26.4 # loosen bounds to accept numpy 2, which appears to be compatible
         - sentencepiece >=0.1.98,<0.3.0
-        - transformers >=4.57.1,<5.0.0
+        # Upstream b9453 pins transformers==5.5.1; align to 5.x major
+        # (pkgs/main currently provides 5.3.0)
+        - transformers >=5.3.0,<6.0.0
         - protobuf >=4.21.0,<7.0.0 # loosen bounds to accept protobuf 5 and 6
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt

--- a/recipe/patches/disable-metal-bf16.patch
+++ b/recipe/patches/disable-metal-bf16.patch
@@ -22,7 +22,7 @@ Can be removed when building with macOS 15+ SDK.
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -212,9 +212,10 @@ ggml_metal_library_t ggml_metal_library_
+@@ -213,9 +213,10 @@ ggml_metal_library_t ggml_metal_library_
                  // dictionary of preprocessor macros
                  NSMutableDictionary * prep = [NSMutableDictionary dictionary];
  
@@ -36,7 +36,7 @@ Can be removed when building with macOS 15+ SDK.
  
                  if (ggml_metal_device_get_props(dev)->has_tensor) {
                      [prep setObject:@"1" forKey:@"GGML_METAL_HAS_TENSOR"];
-@@ -669,9 +670,9 @@ ggml_metal_device_t ggml_metal_device_in
+@@ -714,9 +715,9 @@ ggml_metal_device_t ggml_metal_device_in
              dev->props.has_simdgroup_mm = [dev->mtl_device supportsFamily:MTLGPUFamilyApple7];
              dev->props.has_unified_memory = dev->mtl_device.hasUnifiedMemory;
  

--- a/recipe/patches/disable-metal-flash-attention.patch
+++ b/recipe/patches/disable-metal-flash-attention.patch
@@ -20,7 +20,7 @@ when building with macOS 15+ SDK.
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -1165,6 +1165,10 @@ bool ggml_metal_device_supports_op(ggml_
+@@ -1212,6 +1212,10 @@ bool ggml_metal_device_supports_op(ggml_
          case GGML_OP_ROLL:
              return true;
          case GGML_OP_FLASH_ATTN_EXT:

--- a/recipe/patches/fix-convert_hf_to_gguf.patch
+++ b/recipe/patches/fix-convert_hf_to_gguf.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Xianglong Kong <xkong@anaconda.com>
+Date: Mon, 1 Jun 2026 12:00:00 -0500
+Subject: [PATCH] redirect conversion package import to llama_cpp_tools.conversion
+
+Upstream b9445+ refactored the model definitions out of convert_hf_to_gguf.py
+into a new top-level `conversion/` Python package. The convert scripts now
+do `from conversion import ...`, which only resolves when run from the source
+tree.
+
+This feedstock installs the scripts as `llama_cpp_tools.<script>` console
+entry points and also copies the `conversion/` package alongside them as
+`llama_cpp_tools.conversion`. Redirect the import so the entry point resolves
+after install.
+
+---
+ convert_hf_to_gguf.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/convert_hf_to_gguf.py
++++ b/convert_hf_to_gguf.py
+@@ -15,7 +15,7 @@ if 'NO_LOCAL_GGUF' not in os.environ:
+     sys.path.insert(1, str(Path(__file__).parent / 'gguf-py'))
+ import gguf
+ 
+-from conversion import (
++from llama_cpp_tools.conversion import (
+     ModelBase,
+     ModelType,
+     get_model_architecture,

--- a/recipe/patches/fix-convert_lora_to_gguf.patch
+++ b/recipe/patches/fix-convert_lora_to_gguf.patch
@@ -18,16 +18,16 @@ and the import statement and `if __name__ == '__main__':` block are updated to f
 
 --- a/convert_lora_to_gguf.py
 +++ b/convert_lora_to_gguf.py
-@@ -24,7 +24,7 @@ if 'NO_LOCAL_GGUF' not in os.environ:
- import gguf
- 
- # reuse model definitions from convert_hf_to_gguf.py
--from convert_hf_to_gguf import LazyTorchTensor, ModelBase
-+from llama_cpp_tools.convert_hf_to_gguf import LazyTorchTensor, ModelBase
- 
+@@ -25,7 +25,7 @@ import gguf
  from gguf.constants import GGUFValueType
  
-@@ -298,7 +298,7 @@ def load_hparams_from_hf(hf_model_id: st
+ # reuse model definitions from the conversion/ package
+-from conversion import LazyTorchTensor, ModelBase, get_model_class
++from llama_cpp_tools.conversion import LazyTorchTensor, ModelBase, get_model_class
+ 
+ logger = logging.getLogger("lora-to-gguf")
+ 
+@@ -330,7 +330,7 @@ def load_hparams_from_hf(hf_model_id: st
      return config.to_dict(), cache_dir
  
  

--- a/recipe/patches/fix-models-path.patch
+++ b/recipe/patches/fix-models-path.patch
@@ -1,21 +1,24 @@
 From 3ea0eac09703ea067e29c7460afd72c063a6b19f Mon Sep 17 00:00:00 2001
 From: John Noller <jnoller@anaconda.com>
 Date: Sun, 20 Jul 2025 14:37:44 -0400
-Subject: [PATCH] fix convert_hf_to_gguf.py
+Subject: [PATCH] locate ggml-vocab gguf files relative to the conversion package
 
-convert_hf_to_gguf.py uses relative paths to the models directory that break when run from a different
-parent directory. When the models are installed in a conda package, the script needs to use
-Path(__file__).parent instead of sys.path[0] to correctly locate the models directory.
+`_set_vocab_builtin` (moved from convert_hf_to_gguf.py into conversion/base.py
+in b9445+) loads `models/ggml-vocab-*.gguf` via `Path(sys.path[0]) / "models"`,
+which only resolves when run from the source tree. The feedstock installs the
+vocab files at `llama_cpp_tools/models/`, so use
+`Path(__file__).parent.parent / "models"` (conversion/base.py becomes
+llama_cpp_tools/conversion/base.py, two parents up reaches the models dir).
 
 ---
---- a/convert_hf_to_gguf.py
-+++ b/convert_hf_to_gguf.py
-@@ -1797,7 +1797,7 @@ class TextModel(ModelBase):
+--- a/conversion/base.py
++++ b/conversion/base.py
+@@ -1969,7 +1969,7 @@ class TextModel(ModelBase):
          special_vocab.add_to_gguf(self.gguf_writer)
  
      def _set_vocab_builtin(self, model_name: Literal["gpt-neox", "llama-spm"], vocab_size: int):
 -        tokenizer_path = Path(sys.path[0]) / "models" / f"ggml-vocab-{model_name}.gguf"
-+        tokenizer_path = Path(__file__).parent / "models" / f"ggml-vocab-{model_name}.gguf"
++        tokenizer_path = Path(__file__).parent.parent / "models" / f"ggml-vocab-{model_name}.gguf"
          logger.warning(f"Using tokenizer from '{os.path.relpath(tokenizer_path, os.getcwd())}'")
          vocab_reader = gguf.GGUFReader(tokenizer_path, "r")
  

--- a/recipe/patches/fix-test-llama-archs-backend-dl.patch
+++ b/recipe/patches/fix-test-llama-archs-backend-dl.patch
@@ -17,7 +17,7 @@ Upstream issue: https://github.com/ggml-org/llama.cpp/issues/20611
 
 --- a/tests/test-llama-archs.cpp
 +++ b/tests/test-llama-archs.cpp
-@@ -607,6 +607,7 @@ static int test_backends(const llm_arch
+@@ -636,6 +636,7 @@ static int test_backends(const llm_arch
  int main(int argc, char ** argv) {
      // FIXME these tests are disabled in the CI for macOS-latest-cmake-arm64 because they are segfaulting
      common_init();

--- a/recipe/patches/increase-nmse-tolerance-aarch64.patch
+++ b/recipe/patches/increase-nmse-tolerance-aarch64.patch
@@ -23,7 +23,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
 
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -3853,7 +3853,7 @@ struct test_mul_mat : public test_case {
+@@ -4004,7 +4004,7 @@ struct test_mul_mat : public test_case {
      }
  
      double max_nmse_err() override {
@@ -32,7 +32,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -3989,7 +3989,7 @@ struct test_mul_mat_id : public test_cas
+@@ -4193,7 +4193,7 @@ struct test_mul_mat_id : public test_cas
      }
  
      double max_nmse_err() override {
@@ -41,7 +41,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4057,7 +4057,7 @@ struct test_mul_mat_id_fusion : public t
+@@ -4261,7 +4261,7 @@ struct test_mul_mat_id_fusion : public t
      }
  
      double max_nmse_err() override {
@@ -50,7 +50,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -4136,7 +4136,7 @@ struct test_out_prod : public test_case
+@@ -4340,7 +4340,7 @@ struct test_out_prod : public test_case
      }
  
      double max_nmse_err() override {
@@ -59,7 +59,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      test_out_prod(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
-@@ -4895,7 +4895,7 @@ struct test_conv_transpose_2d : public t
+@@ -5112,7 +5112,7 @@ struct test_conv_transpose_2d : public t
      }
  
      double max_nmse_err() override {
@@ -68,7 +68,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      test_conv_transpose_2d(
-@@ -5049,7 +5049,7 @@ struct test_conv_2d : public test_case {
+@@ -5266,7 +5266,7 @@ struct test_conv_2d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -77,7 +77,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5181,7 +5181,7 @@ struct test_conv_3d : public test_case {
+@@ -5398,7 +5398,7 @@ struct test_conv_3d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -86,7 +86,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5686,7 +5686,7 @@ struct test_mul_mat_vec_fusion : public
+@@ -5903,7 +5903,7 @@ struct test_mul_mat_vec_fusion : public
      }
  
      double max_nmse_err() override {
@@ -95,7 +95,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  };
  
-@@ -6252,7 +6252,7 @@ struct test_flash_attn_ext : public test
+@@ -6470,7 +6470,7 @@ struct test_flash_attn_ext : public test
      }
  
      double max_nmse_err() override {

--- a/recipe/patches/increase-nmse-tolerance.patch
+++ b/recipe/patches/increase-nmse-tolerance.patch
@@ -17,7 +17,7 @@ Updated for b8994.
 
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -3853,7 +3853,7 @@ struct test_mul_mat : public test_case {
+@@ -4004,7 +4004,7 @@ struct test_mul_mat : public test_case {
      }
  
      double max_nmse_err() override {
@@ -26,7 +26,7 @@ Updated for b8994.
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -3989,7 +3989,7 @@ struct test_mul_mat_id : public test_cas
+@@ -4193,7 +4193,7 @@ struct test_mul_mat_id : public test_cas
      }
  
      double max_nmse_err() override {
@@ -35,7 +35,7 @@ Updated for b8994.
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4057,7 +4057,7 @@ struct test_mul_mat_id_fusion : public t
+@@ -4261,7 +4261,7 @@ struct test_mul_mat_id_fusion : public t
      }
  
      double max_nmse_err() override {
@@ -44,7 +44,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -4136,7 +4136,7 @@ struct test_out_prod : public test_case
+@@ -4340,7 +4340,7 @@ struct test_out_prod : public test_case
      }
  
      double max_nmse_err() override {
@@ -53,7 +53,7 @@ Updated for b8994.
      }
  
      test_out_prod(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
-@@ -4895,7 +4895,7 @@ struct test_conv_transpose_2d : public t
+@@ -5112,7 +5112,7 @@ struct test_conv_transpose_2d : public t
      }
  
      double max_nmse_err() override {
@@ -62,7 +62,7 @@ Updated for b8994.
      }
  
      test_conv_transpose_2d(
-@@ -5049,7 +5049,7 @@ struct test_conv_2d : public test_case {
+@@ -5266,7 +5266,7 @@ struct test_conv_2d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -71,7 +71,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5181,7 +5181,7 @@ struct test_conv_3d : public test_case {
+@@ -5398,7 +5398,7 @@ struct test_conv_3d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -80,7 +80,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -6252,7 +6252,7 @@ struct test_flash_attn_ext : public test
+@@ -6470,7 +6470,7 @@ struct test_flash_attn_ext : public test
      }
  
      double max_nmse_err() override {

--- a/recipe/patches/metal_gpu_selection.patch
+++ b/recipe/patches/metal_gpu_selection.patch
@@ -18,7 +18,7 @@ Updated for b8994. File rename from ggml/src/ggml-metal/ggml-metal.m to ggml-met
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -634,6 +634,25 @@ ggml_metal_device_t ggml_metal_device_in
+@@ -679,6 +679,25 @@ ggml_metal_device_t ggml_metal_device_in
  
      if (dev->mtl_device == nil) {
          dev->mtl_device = MTLCreateSystemDefaultDevice();

--- a/recipe/patches/skip-test-chat-without-server.patch
+++ b/recipe/patches/skip-test-chat-without-server.patch
@@ -26,7 +26,7 @@ block are unaffected.
 
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
-@@ -154,9 +154,11 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
+@@ -155,9 +155,11 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
      llama_build_and_test(test-grammar-parser.cpp)
      llama_build_and_test(test-grammar-integration.cpp)
      llama_build_and_test(test-llama-grammar.cpp)


### PR DESCRIPTION
llama.cpp b9453

**Destination channel:** defaults

### Links

- [PKG-13215](https://anaconda.atlassian.net/browse/PKG-13215)
- [Upstream repository](https://github.com/ggml-org/llama.cpp)
- [Upstream release notes (b9453)](https://github.com/ggml-org/llama.cpp/releases/tag/b9453)
- [Upstream diff b8994..b9453](https://github.com/ggml-org/llama.cpp/compare/b8994...b9453)
- Relevant dependency PRs:
  - none

### Explanation of changes:

- **Version bump:** `b8994` → `b9453` (released 2026-06-01). 




[PKG-13215]: https://anaconda.atlassian.net/browse/PKG-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ