### PR TITLE
llama.cpp 0.0.9848

### DIFF
--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -72,7 +72,12 @@ cmake -S . -B build ^
     !LLAMA_ARGS!
 if errorlevel 1 exit 1
 
-cmake --build build --config Release --verbose
+REM Cap ninja parallelism on CUDA builds — CLAIM_EXPIRED workaround (SIR-3267 followup).
+REM GGML_CPU_ALL_VARIANTS=ON generates 15 backends; combined with cublas linking the
+REM Windows worker's memory saturates and starves the TaskCluster heartbeat monitor.
+set BUILD_JOBS=%CPU_COUNT%
+if "%gpu_variant:~0,5%"=="cuda-" set BUILD_JOBS=4
+cmake --build build --config Release --verbose --parallel %BUILD_JOBS%
 if errorlevel 1 exit 1
 
 cmake --install build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -301,10 +301,6 @@ outputs:
         - llama-convert-llama-ggml-to-gguf = llama_cpp_tools.convert_llama_ggml_to_gguf:main
         - llama-convert-lora-to-gguf = llama_cpp_tools.convert_lora_to_gguf:main
       skip: True # [py<39]
-      # Keep py314 skipped: mistral-common has no py314 build on pkgs/main yet
-      # (latest 1.11.2 tops out at py313). transformers/pytorch/sentencepiece are
-      # already py314-ready, so lift this once mistral-common ships for py314.
-      skip: true # [py>313]
       skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b9453" %}
-{% set upstream_commit = "48b88c3b0057fcf1171f8d62ff9f6b10de27a11e" %}
+{% set upstream_release = "b9848" %}
+{% set upstream_commit = "931eb37f8cac5a6ca84d5641445d460af2a9d7dd" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.18.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -22,7 +22,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: 3d755128d1b329c186a96e4a13f7b4fe1fe80067b6f21c56d742153bfc165e1a
+  sha256: 422610d99e6a579ed5aefdb02746768828315a7ed870b43fe7018dcb3714e807
 
   patches:
     - patches/increase-nmse-tolerance.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,14 @@
 # So we set them to 999.0a0 to avoid the render error.
 # Setting to 999.0a0 is safe because if they ever get used in the build, they
 # will generate a solve error.
-{% if output_set == "llama_cpp_tools" %}
-{% set mkl = "999.0a0" %}
-{% set openblas = "999.0a0" %}
-{% set cuda_compiler_version = "999.0a0" %}
-{% endif %}
+# NOTE: expressed as `{% set %}` with the `default` filter rather than a
+# `{% if %}` block because the Anaconda Linter's recipe parser does not support
+# `{% if %}` statements (parsing_jinja_failure). For the "llama" output_set these
+# variables are supplied by conda_build_config.yaml and are kept as-is; for the
+# "llama_cpp_tools" output_set they are undefined, so they fall back to 999.0a0.
+{% set mkl = mkl | default("999.0a0", true) %}
+{% set openblas = openblas | default("999.0a0", true) %}
+{% set cuda_compiler_version = cuda_compiler_version | default("999.0a0", true) %}
 
 package:
   name: {{ name|lower }}
@@ -298,6 +301,9 @@ outputs:
         - llama-convert-llama-ggml-to-gguf = llama_cpp_tools.convert_llama_ggml_to_gguf:main
         - llama-convert-lora-to-gguf = llama_cpp_tools.convert_lora_to_gguf:main
       skip: True # [py<39]
+      # Keep py314 skipped: mistral-common has no py314 build on pkgs/main yet
+      # (latest 1.11.2 tops out at py313). transformers/pytorch/sentencepiece are
+      # already py314-ready, so lift this once mistral-common ships for py314.
       skip: true # [py>313]
       skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
@@ -365,9 +371,8 @@ outputs:
         - gguf-dump = gguf.scripts.gguf_dump:main
         - gguf-set-metadata = gguf.scripts.gguf_set_metadata:main
         - gguf-new-metadata = gguf.scripts.gguf_new_metadata:main
-        - gguf-editor-gui = gguf.scripts.gguf_editor_gui:main      
+        - gguf-editor-gui = gguf.scripts.gguf_editor_gui:main
       skip: True # [py<39]
-      skip: true # [py>313]
       skip: true # [output_set != "llama_cpp_tools"]
       number: {{ build_number }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -323,8 +323,14 @@ outputs:
         # transformers 5.9.0, so we require >=5.9.0 as the minimum version
         # containing the fix.
         - transformers >=5.9.0,<6.0.0
-        # Match upstream cap (requirements-convert_legacy_llama.txt@b9848).
-        - protobuf >=4.21.0,<5.0.0
+        # Upstream caps at protobuf<5.0, but we can't match that on pkgs/main:
+        # the only <5.0 build (protobuf 4.25.3) requires libabseil ~20240116,
+        # while every pytorch >=2.6.0 build on pkgs/main requires libabseil
+        # >=20250127. The tighter upstream cap is therefore unsolvable
+        # alongside our pytorch>=2.6.0 run-dep. The previous release (b9453)
+        # shipped with protobuf 5.x via the same widened bound and CI tests
+        # (`llama-convert-hf-to-gguf --help` etc.) passed on all platforms.
+        - protobuf >=5.29.3,<7.0.0
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt
         # requirements/requirements-convert_lora_to_gguf.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set upstream_release = "b9848" %}
 {% set upstream_commit = "931eb37f8cac5a6ca84d5641445d460af2a9d7dd" %}
 {% set version = "0.0." + upstream_release[1:] %}
-{% set gguf_version = "0.18.0." + upstream_release[1:] %}
+{% set gguf_version = "0.19.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
 
 # When output_set is llama_cpp_tools, PBP trips on undefined variables

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -323,13 +323,27 @@ outputs:
         # transformers 5.9.0, so we require >=5.9.0 as the minimum version
         # containing the fix.
         - transformers >=5.9.0,<6.0.0
-        # Upstream caps at protobuf<5.0, but we can't match that on pkgs/main:
-        # the only <5.0 build (protobuf 4.25.3) requires libabseil ~20240116,
+        # Upstream requirements-convert_legacy_llama.txt lists
+        # `protobuf>=4.21.0,<5.0.0`, but that cap is stale: it was introduced
+        # in llama.cpp commit 04ac060 (Dec 2023, before protobuf 5.x existed)
+        # and has been carried forward unchanged for 2+ years without any
+        # release-note or PR justifying it. The convert scripts themselves do
+        # NOT import protobuf directly (no `import protobuf` / `google.protobuf`
+        # in convert_hf_to_gguf.py, convert_lora_to_gguf.py, or
+        # convert_llama_ggml_to_gguf.py at b9848). protobuf is only pulled in
+        # transitively by transformers' T5/mBART/XLNet tokenizer classes when
+        # those specific model families are instantiated, so we still ship it
+        # as a run: dep for feature completeness.
+        # We cannot match the upstream `<5.0` cap on pkgs/main because the
+        # only such build (protobuf 4.25.3) requires libabseil ~20240116,
         # while every pytorch >=2.6.0 build on pkgs/main requires libabseil
-        # >=20250127. The tighter upstream cap is therefore unsolvable
-        # alongside our pytorch>=2.6.0 run-dep. The previous release (b9453)
-        # shipped with protobuf 5.x via the same widened bound and CI tests
-        # (`llama-convert-hf-to-gguf --help` etc.) passed on all platforms.
+        # >=20250127. Widening to protobuf 5.x/6.x is safe here because
+        # (a) our recipe does not `pip install` (build-llama-cpp-tools.sh
+        # just cps files into $SP_DIR), so no dist-info metadata enforces
+        # upstream's constraint, and (b) sentencepiece 0.2.x on pkgs/main
+        # statically links libprotobuf and does not have a runtime protobuf
+        # dep, so the ABI decoupling insulates us from protobuf major-version
+        # shifts.
         - protobuf >=5.29.3,<7.0.0
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -316,10 +316,15 @@ outputs:
         # requirements/requirements-convert_legacy_llama.txt
         - numpy >=1.26.4 # loosen bounds to accept numpy 2, which appears to be compatible
         - sentencepiece >=0.1.98,<0.3.0
-        # Upstream b9453 pins transformers==5.5.1; align to 5.x major
-        # (pkgs/main currently provides 5.3.0)
-        - transformers >=5.3.0,<6.0.0
-        - protobuf >=4.21.0,<7.0.0 # loosen bounds to accept protobuf 5 and 6
+        # Upstream b9848 pins transformers==4.57.6 for a rope/yarn converter
+        # fix (huggingface/transformers#45887, merge commit dfcb1a3, 2026-05-12;
+        # cherry-picked into the 4.57.x maintenance branch). pkgs/main lacks
+        # 4.57.6 (only has 4.57.1), but the same fix is an ancestor of
+        # transformers 5.9.0, so we require >=5.9.0 as the minimum version
+        # containing the fix.
+        - transformers >=5.9.0,<6.0.0
+        # Match upstream cap (requirements-convert_legacy_llama.txt@b9848).
+        - protobuf >=4.21.0,<5.0.0
         # requirements/requirements-convert_hf_to_gguf.txt
         # requirements/requirements-convert_llama_ggml_to_gguf.txt
         # requirements/requirements-convert_lora_to_gguf.txt

--- a/recipe/patches/fix-convert_lora_to_gguf.patch
+++ b/recipe/patches/fix-convert_lora_to_gguf.patch
@@ -22,12 +22,12 @@ and the import statement and `if __name__ == '__main__':` block are updated to f
  from gguf.constants import GGUFValueType
  
  # reuse model definitions from the conversion/ package
--from conversion import LazyTorchTensor, ModelBase, get_model_class
-+from llama_cpp_tools.conversion import LazyTorchTensor, ModelBase, get_model_class
+-from conversion import LazyTorchTensor, ModelBase, get_model_class, ModelType, get_model_architecture
++from llama_cpp_tools.conversion import LazyTorchTensor, ModelBase, get_model_class, ModelType, get_model_architecture
  
  logger = logging.getLogger("lora-to-gguf")
  
-@@ -330,7 +330,7 @@ def load_hparams_from_hf(hf_model_id: st
+@@ -334,7 +334,7 @@ def load_hparams_from_hf(hf_model_id: st
      return config.to_dict(), cache_dir
  
  


### PR DESCRIPTION
## llama.cpp 0.0.9848

**Destination channel:** defaults

### Links

- [PKG-13216](https://anaconda.atlassian.net/browse/PKG-13216)
- [Upstream release](https://github.com/ggml-org/llama.cpp/releases/tag/b9848)
- [Upstream diff b9453 → b9848](https://github.com/ggml-org/llama.cpp/compare/b9453...b9848)

### Explanation of changes:

- Update llama.cpp from b9453 to b9848 (upstream released 2026-06-30; ~395 commits).
- Refresh `fix-convert_lora_to_gguf.patch`: upstream extended the `from conversion import …` line to additionally import `ModelType, get_model_architecture`, so the namespaced rewrite needs to mirror the new tail.
- CUDA matrix unchanged (`12.9`, `13.0`). CUDA 13.2 is available on pkgs/main (libcublas-dev 13.2.1.1 / 13.2.2.2) and verified per scoping note in the ticket; promotion deferred to a follow-up if desired.
- `LLAMA_BUILD_APP=OFF` workaround in `build-llama-cpp.{sh,bat}` retained — `app/CMakeLists.txt` in b9848 still doesn't wire the `common/build-info.h` include path. Tracked upstream in ggml-org/llama.cpp#23628.
- Other 9 patches apply with line-number offsets only; no content changes.

[PKG-13216]: https://anaconda.atlassian.net/browse/PKG-13216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ