### PR TITLE
update to b10241

### DIFF
--- a/recipe/bld-llama-cpp.bat
+++ b/recipe/bld-llama-cpp.bat
@@ -33,6 +33,9 @@ if "%blas_impl%"=="mkl" (
 REM LLAMA build options
 set LLAMA_ARGS=-DLLAMA_BUILD_NUMBER=%LLAMA_BUILD_NUMBER% -DLLAMA_BUILD_COMMIT=%LLAMA_BUILD_COMMIT%
 set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_OPENSSL=ON
+REM Disable common/subproc.cpp for parity with Linux (see build-llama-cpp.sh).
+REM Only server MCP/tools/router consume it, neither is exposed by our binaries.
+set LLAMA_ARGS=!LLAMA_ARGS! -DLLAMA_SUBPROCESS=OFF
 REM Disable the unified `llama` router app: it #includes common/build-info.h but
 REM the upstream app/CMakeLists.txt does not wire up its include path, so the
 REM build fails with "fatal error: build-info.h: No such file or directory".

--- a/recipe/build-llama-cpp.sh
+++ b/recipe/build-llama-cpp.sh
@@ -64,6 +64,12 @@ fi
 # LLAMA build options
 LLAMA_ARGS="-DLLAMA_BUILD_NUMBER=${LLAMA_BUILD_NUMBER} -DLLAMA_BUILD_COMMIT=${LLAMA_BUILD_COMMIT}"
 LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_OPENSSL=ON"
+# Disable common/subproc.cpp (added b10241, ggml-org/llama.cpp#26102). It pulls
+# vendored sheredom/subprocess.h whose Linux path calls
+# posix_spawn_file_actions_addchdir_np() unconditionally, requiring glibc>=2.29;
+# AR CentOS 7 sysroot ships glibc 2.28. Only server MCP/tools/router use this,
+# and neither is exposed by our binaries.
+LLAMA_ARGS="${LLAMA_ARGS} -DLLAMA_SUBPROCESS=OFF"
 # Disable the unified `llama` router app: it #includes common/build-info.h but the
 # upstream app/CMakeLists.txt does not wire up its include path, so the build fails
 # with `fatal error: build-info.h: No such file or directory` on every platform.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "llama.cpp-meta" %}
-{% set upstream_release = "b10068" %}
-{% set upstream_commit = "571d0d540df04f25298d0e159e520d9fc62ed121" %}
+{% set upstream_release = "b10241" %}
+{% set upstream_commit = "9bd4c09ea571a9020f30eeef169b552625b5b5a4" %}
 {% set version = "0.0." + upstream_release[1:] %}
 {% set gguf_version = "0.19.0." + upstream_release[1:] %}
 {% set build_number = 0 %}
@@ -25,7 +25,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/llama.cpp/archive/{{ upstream_release }}.tar.gz
-  sha256: 192819ca7117147532f2c8d8938ab2fe9b25e872ea671a56be549ec30ea4f743
+  sha256: cadadd9975219589290acbe262c903790af9208d704046775248a9578176d1f5
 
   patches:
     - patches/increase-nmse-tolerance.patch

--- a/recipe/patches/disable-metal-bf16.patch
+++ b/recipe/patches/disable-metal-bf16.patch
@@ -22,7 +22,7 @@ Can be removed when building with macOS 15+ SDK.
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -213,9 +213,10 @@ ggml_metal_library_t ggml_metal_library_
+@@ -214,9 +214,10 @@ ggml_metal_library_t ggml_metal_library_
                  // dictionary of preprocessor macros
                  NSMutableDictionary * prep = [NSMutableDictionary dictionary];
  
@@ -36,7 +36,7 @@ Can be removed when building with macOS 15+ SDK.
  
                  if (ggml_metal_device_get_props(dev)->has_tensor) {
                      [prep setObject:@"1" forKey:@"GGML_METAL_HAS_TENSOR"];
-@@ -718,9 +719,9 @@ ggml_metal_device_t ggml_metal_device_in
+@@ -753,9 +754,9 @@ ggml_metal_device_t ggml_metal_device_in
              dev->props.has_simdgroup_mm = [dev->mtl_device supportsFamily:MTLGPUFamilyApple7];
              dev->props.has_unified_memory = dev->mtl_device.hasUnifiedMemory;
  

--- a/recipe/patches/disable-metal-flash-attention.patch
+++ b/recipe/patches/disable-metal-flash-attention.patch
@@ -20,7 +20,7 @@ when building with macOS 15+ SDK.
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -1245,6 +1245,10 @@ bool ggml_metal_device_supports_op(ggml_
+@@ -1290,6 +1290,10 @@ bool ggml_metal_device_supports_op(ggml_
          case GGML_OP_ROLL:
              return true;
          case GGML_OP_FLASH_ATTN_EXT:

--- a/recipe/patches/fix-models-path.patch
+++ b/recipe/patches/fix-models-path.patch
@@ -13,7 +13,7 @@ llama_cpp_tools/conversion/base.py, two parents up reaches the models dir).
 ---
 --- a/conversion/base.py
 +++ b/conversion/base.py
-@@ -1994,7 +1994,7 @@ class TextModel(ModelBase):
+@@ -1997,7 +1997,7 @@ class TextModel(ModelBase):
          special_vocab.add_to_gguf(self.gguf_writer)
  
      def _set_vocab_builtin(self, model_name: Literal["gpt-neox", "llama-spm"], vocab_size: int):

--- a/recipe/patches/fix-test-llama-archs-backend-dl.patch
+++ b/recipe/patches/fix-test-llama-archs-backend-dl.patch
@@ -17,7 +17,7 @@ Upstream issue: https://github.com/ggml-org/llama.cpp/issues/20611
 
 --- a/tests/test-llama-archs.cpp
 +++ b/tests/test-llama-archs.cpp
-@@ -650,6 +650,7 @@ static int test_backends(const llm_arch
+@@ -656,6 +656,7 @@ static int test_backends(const llm_arch
  int main(int argc, char ** argv) {
      // FIXME these tests are disabled in the CI for macOS-latest-cmake-arm64 because they are segfaulting
      common_init();

--- a/recipe/patches/increase-nmse-tolerance-aarch64.patch
+++ b/recipe/patches/increase-nmse-tolerance-aarch64.patch
@@ -23,7 +23,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
 
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -4238,7 +4238,7 @@ struct test_mul_mat : public test_case {
+@@ -4252,7 +4252,7 @@ struct test_mul_mat : public test_case {
      }
  
      double max_nmse_err() override {
@@ -32,7 +32,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4427,7 +4427,7 @@ struct test_mul_mat_id : public test_cas
+@@ -4441,7 +4441,7 @@ struct test_mul_mat_id : public test_cas
      }
  
      double max_nmse_err() override {
@@ -41,7 +41,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4495,7 +4495,7 @@ struct test_mul_mat_id_fusion : public t
+@@ -4509,7 +4509,7 @@ struct test_mul_mat_id_fusion : public t
      }
  
      double max_nmse_err() override {
@@ -50,7 +50,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -4574,7 +4574,7 @@ struct test_out_prod : public test_case
+@@ -4588,7 +4588,7 @@ struct test_out_prod : public test_case
      }
  
      double max_nmse_err() override {
@@ -59,7 +59,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      test_out_prod(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
-@@ -5379,7 +5379,7 @@ struct test_conv_transpose_2d : public t
+@@ -5393,7 +5393,7 @@ struct test_conv_transpose_2d : public t
      }
  
      double max_nmse_err() override {
@@ -68,7 +68,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      test_conv_transpose_2d(
-@@ -5533,7 +5533,7 @@ struct test_conv_2d : public test_case {
+@@ -5547,7 +5547,7 @@ struct test_conv_2d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -77,7 +77,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5668,7 +5668,7 @@ struct test_conv_3d : public test_case {
+@@ -5682,7 +5682,7 @@ struct test_conv_3d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -86,7 +86,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -6239,7 +6239,7 @@ struct test_mul_mat_vec_fusion : public
+@@ -6255,7 +6255,7 @@ struct test_mul_mat_vec_fusion : public
      }
  
      double max_nmse_err() override {
@@ -95,7 +95,7 @@ Updated for b8994: Adjusted for new line numbers (9 instances).
      }
  };
  
-@@ -6814,7 +6814,7 @@ struct test_flash_attn_ext : public test
+@@ -6830,7 +6830,7 @@ struct test_flash_attn_ext : public test
      }
  
      double max_nmse_err() override {

--- a/recipe/patches/increase-nmse-tolerance.patch
+++ b/recipe/patches/increase-nmse-tolerance.patch
@@ -17,7 +17,7 @@ Updated for b8994.
 
 --- a/tests/test-backend-ops.cpp
 +++ b/tests/test-backend-ops.cpp
-@@ -4238,7 +4238,7 @@ struct test_mul_mat : public test_case {
+@@ -4252,7 +4252,7 @@ struct test_mul_mat : public test_case {
      }
  
      double max_nmse_err() override {
@@ -26,7 +26,7 @@ Updated for b8994.
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4427,7 +4427,7 @@ struct test_mul_mat_id : public test_cas
+@@ -4441,7 +4441,7 @@ struct test_mul_mat_id : public test_cas
      }
  
      double max_nmse_err() override {
@@ -35,7 +35,7 @@ Updated for b8994.
      }
  
      double max_nmse_err(ggml_backend_t backend) override {
-@@ -4495,7 +4495,7 @@ struct test_mul_mat_id_fusion : public t
+@@ -4509,7 +4509,7 @@ struct test_mul_mat_id_fusion : public t
      }
  
      double max_nmse_err() override {
@@ -44,7 +44,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -4574,7 +4574,7 @@ struct test_out_prod : public test_case
+@@ -4588,7 +4588,7 @@ struct test_out_prod : public test_case
      }
  
      double max_nmse_err() override {
@@ -53,7 +53,7 @@ Updated for b8994.
      }
  
      test_out_prod(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
-@@ -5379,7 +5379,7 @@ struct test_conv_transpose_2d : public t
+@@ -5393,7 +5393,7 @@ struct test_conv_transpose_2d : public t
      }
  
      double max_nmse_err() override {
@@ -62,7 +62,7 @@ Updated for b8994.
      }
  
      test_conv_transpose_2d(
-@@ -5533,7 +5533,7 @@ struct test_conv_2d : public test_case {
+@@ -5547,7 +5547,7 @@ struct test_conv_2d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -71,7 +71,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -5668,7 +5668,7 @@ struct test_conv_3d : public test_case {
+@@ -5682,7 +5682,7 @@ struct test_conv_3d : public test_case {
      }
  
      double max_nmse_err() override {
@@ -80,7 +80,7 @@ Updated for b8994.
      }
  
      uint64_t op_flops(ggml_tensor * t) override {
-@@ -6814,7 +6814,7 @@ struct test_flash_attn_ext : public test
+@@ -6830,7 +6830,7 @@ struct test_flash_attn_ext : public test
      }
  
      double max_nmse_err() override {

--- a/recipe/patches/metal_gpu_selection.patch
+++ b/recipe/patches/metal_gpu_selection.patch
@@ -18,7 +18,7 @@ Updated for b8994. File rename from ggml/src/ggml-metal/ggml-metal.m to ggml-met
 
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -683,6 +683,25 @@ ggml_metal_device_t ggml_metal_device_in
+@@ -718,6 +718,25 @@ ggml_metal_device_t ggml_metal_device_in
  
      if (dev->mtl_device == nil) {
          dev->mtl_device = MTLCreateSystemDefaultDevice();


### PR DESCRIPTION
llama.cpp b10241

**Destination channel:** defaults

### Links

- [PKG-16386](https://anaconda.atlassian.net/browse/PKG-16386)
- [Upstream repository](https://github.com/ggml-org/llama.cpp)
- [Upstream diff b10068...b10241](https://github.com/ggml-org/llama.cpp/compare/b10068...b10241)

### Explanation of changes

- Bump from `b10068` to `b10241` (173 upstream commits).


### Notable upstream changes

- CUDA: Fix data-races when reusing SMEM in block_reduce (#26385)
- MTP support for Qwen3-Next (#25589) and DeepSeek V3.2 (#26457)
- server: tools x-tool-cwd header (#26420), upcoming default port change notice (#26508)
- vulkan: refactor vk_queue for per-instance mutexes (#23570)
- OpenCL: broadcast + `view_offs` fixes for Adreno multi-stream (#25910)


[PKG-16386]: https://anaconda.atlassian.net/browse/PKG-16386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ